### PR TITLE
updated dataset def for consultation mode counting

### DIFF
--- a/analysis/dataset_definition_patients.py
+++ b/analysis/dataset_definition_patients.py
@@ -32,7 +32,7 @@ Patient table key fields:
 - Appointment count: scheduled; seen.
 - PF consultation count for each condition
 - GP consultation count for each condition
-- GP consultation for each condition, by consultation mode (f2f, online, telephone, other)
+- GP condition patient-date counts by consultation mode (f2f, online, telephone, other)
 - Eligibility/clinical characteristics flag (True/False)
 
 Eligibility/clinical characteristics flag for study population denominator:
@@ -208,52 +208,67 @@ for name, codes in all_conditions_gp_codes.items():
 
 ########################################################
 '''
-This section counts the number of GP consultations for PF-related conditions by consultation mode (excluding consultations with PF service codes)
+This section counts PF-related GP condition activity by consultation mode,
+excluding consultations with general PF service codes.
 
 Key logic:
-- 'gp_events_clean' already excludes all consultations with PF service codes (pf_ids).
+- 'gp_events_clean' excludes all events belonging to consultations with general PF service codes (pf_ids).
+- The current implementation uses a patient-date-based approach for consultation mode classification.
+- The previous May 2026 implementation used consultation_id to identify all events within condition-related consultations; this has been retained below as commented-out code for reference.
 
-1. 'pf_conditions_gp_code_set' is creased, including all GP used SNOMED codes for the seven conditions 
-2. events in 'gp_events_clean' are filtered using the combined code set to identify condition-related events.
-3. consultation IDs are then extracted from events in step 2. This set of IDs represents the condition-related consultations without any PF service codes.
-4. retrieve all events within the selected consultation IDs 
-5. consultation mode is classified using specific codelists:
--- version May 2026 ---
-5.1 three sets of events are identified for each consultation type: face-to-face, online, and telephone
-5.2 consultation IDs are extracted for each type/event set
-5.3 a hierarchical assignment is applied:
-- face-to-face takes precedence
-- online excludes consultations already classified as face-to-face
-- telephone excludes consultations classified as face-to-face or online
-- remaining consultations are classified as 'othermode'
-- all counts are based on distinct consultation IDs per patient.
--- version June 2026 ---
-5.1 Consultation dates are identified from all events within condition-related consultations.
-5.2 Dates associated with f2f, online, and telephone consultation-mode codes are identified separately.
-5.3 A hierarchical assignment is applied at the patient-date level:
-- if any f2f code is recorded on a given date, the date is classified as f2f;
-- otherwise, if any online code is recorded, the date is classified as online;
-- otherwise, if any telephone code is recorded, the date is classified as telephone;
-- remaining dates are classified as othermode.
-5.4 All counts are based on distinct dates per patient.
-5.5 As a result, multiple consultations for the same patient on the same date are counted once, with consultation mode assigned according to the hierarchy:
-f2f > online > telephone > othermode.
+1. 'pf_conditions_gp_code_set' is created, including all GP SNOMED codes for the seven PF-related conditions.
+2. Events in 'gp_events_clean' are filtered using the combined code set to identify PF-related GP condition events.
+3. The dates of these condition events are used to define PF-related GP condition patient-dates.
+4. Consultation-mode codes are identified separately from all events in 'gp_events_clean'.
+5. PF-related GP condition patient-dates are classified by matching to consultation-mode patient-dates, using a hierarchical assignment.
+
+-- Version May 2026: consultation_id-based approach --
+5.1 Condition-related events were first identified using the combined PF-related GP condition codelist.
+5.2 Consultation IDs were extracted from these condition-related events.
+5.3 All events belonging to those consultation IDs were retrieved.
+5.4 Face-to-face, online, and telephone mode-code events were identified within those retrieved consultation events.
+5.5 A hierarchical assignment was applied at consultation-ID level:
+- face-to-face took precedence;
+- online excluded consultations already classified as face-to-face;
+- telephone excluded consultations already classified as face-to-face or online;
+- remaining consultations were classified as othermode.
+5.6 Counts were based on distinct consultation IDs per patient.
+
+-- Version June 2026: patient-date-based approach --
+6.1 PF-related GP condition patient-dates are identified directly from condition-specific SNOMED-coded events in 'gp_events_clean'.
+6.2 Patient-dates associated with face-to-face, online, and telephone consultation-mode codes are identified separately from all events in 'gp_events_clean'.
+6.3 A hierarchical assignment is applied to PF-related GP condition patient-dates:
+- if any face-to-face mode code is recorded for the patient on the same date, the date is classified as face-to-face;
+- otherwise, if any online mode code is recorded for the patient on the same date, the date is classified as online;
+- otherwise, if any telephone mode code is recorded for the patient on the same date, the date is classified as telephone;
+- remaining PF-related GP condition patient-dates are classified as othermode.
+6.4 Counts are based on distinct dates per patient, not distinct consultation IDs.
+6.5 Multiple PF-related GP condition events for the same patient on the same date are counted once, with consultation mode assigned according to the hierarchy:
+face-to-face > online > telephone > othermode.
 
 Outputs:
-- gp_pf_consultation_f2f
-- gp_pf_consultation_online
-- gp_pf_consultation_telephone
-- gp_pf_consultation_othermode
+- gp_pf_patient_date_f2f
+- gp_pf_patient_date_online
+- gp_pf_patient_date_telephone
+- gp_pf_patient_date_othermode
+- gp_pf_patient_date_total
+- gp_pf_patient_date_mode_sum
+
+Notes:
+- These outputs are patient-date counts, not distinct consultation-ID counts.
+- The May 2026 consultation-ID-based output variables are retained only in commented-out code for reference.
 '''
+
 pf_conditions_gp_code_set = []
 for codes in pf_conditions_gp_codes.values():
     pf_conditions_gp_code_set += codes
 
 gp_pf_condition_events = gp_events_clean.where(gp_events_clean.snomedct_code.is_in(pf_conditions_gp_code_set))
-gp_pf_condition_ids = gp_pf_condition_events.consultation_id
-gp_pf_condition_all_events = select_events_by_consultation_id(gp_events_clean,gp_pf_condition_ids)
 
 ######### Version May 2026 #########
+# gp_pf_condition_ids = gp_pf_condition_events.consultation_id
+# gp_pf_condition_all_events = select_events_by_consultation_id(gp_events_clean,gp_pf_condition_ids)
+
 # gp_pf_f2f_type_events = select_events_from_codelist(
 #     gp_pf_condition_all_events,
 #     codelists.gp_codelist_consultation_f2f
@@ -296,47 +311,72 @@ gp_pf_condition_all_events = select_events_by_consultation_id(gp_events_clean,gp
 # )
 
 ######### Version June 2026: patient-date level #########
-gp_pf_condition_dates = gp_pf_condition_all_events.date
+# Instead of retrieving all events linked by consultation_id, 
+# first, identify patient-dates with PF-related GP condition codes, 
+# then classify those dates according to whether any face-to-face, online, or telephone consultation mode code was recorded on the same patient-date.
 
-f2f_dates = select_events_from_codelist(
-    gp_pf_condition_all_events,
+gp_f2f_dates = select_events_from_codelist(
+    gp_events_clean,
     codelists.gp_codelist_consultation_f2f
 ).date
 
-online_dates = select_events_from_codelist(
-    gp_pf_condition_all_events,
+gp_online_dates = select_events_from_codelist(
+    gp_events_clean,
     codelists.gp_codelist_consultation_online
 ).date
 
-telephone_dates = select_events_from_codelist(
-    gp_pf_condition_all_events,
+gp_telephone_dates = select_events_from_codelist(
+    gp_events_clean,
     codelists.gp_codelist_consultation_telephone
 ).date
 
-has_f2f = gp_pf_condition_dates.is_in(f2f_dates)
-has_online = gp_pf_condition_dates.is_in(online_dates)
-has_telephone = gp_pf_condition_dates.is_in(telephone_dates)
+gp_pf_f2f = gp_pf_condition_events.where(
+    gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    )
+gp_pf_online = gp_pf_condition_events.where(
+    ~gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    & gp_pf_condition_events.date.is_in(gp_online_dates)
+    )
+gp_pf_telephone = gp_pf_condition_events.where(
+    ~gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_pf_condition_events.date.is_in(gp_online_dates)
+    & gp_pf_condition_events.date.is_in(gp_telephone_dates)
+    )
+gp_pf_other = gp_pf_condition_events.where(
+    ~gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_pf_condition_events.date.is_in(gp_online_dates)
+    & ~gp_pf_condition_events.date.is_in(gp_telephone_dates)
+    )
 
-gp_pf_f2f = gp_pf_condition_all_events.where(has_f2f)
-gp_pf_online = gp_pf_condition_all_events.where(~has_f2f & has_online)
-gp_pf_telephone = gp_pf_condition_all_events.where(~has_f2f & ~has_online & has_telephone)
-gp_pf_other = gp_pf_condition_all_events.where(~has_f2f & ~has_online & ~has_telephone)
+dataset.gp_pf_patient_date_f2f = (gp_pf_f2f.date.count_distinct_for_patient())
+dataset.gp_pf_patient_date_online = (gp_pf_online.date.count_distinct_for_patient())
+dataset.gp_pf_patient_date_telephone = (gp_pf_telephone.date.count_distinct_for_patient())
+dataset.gp_pf_patient_date_othermode = (gp_pf_other.date.count_distinct_for_patient())
 
-dataset.gp_pf_consultation_f2f = (gp_pf_f2f.date.count_distinct_for_patient())
-dataset.gp_pf_consultation_online = (gp_pf_online.date.count_distinct_for_patient())
-dataset.gp_pf_consultation_telephone = (gp_pf_telephone.date.count_distinct_for_patient())
-dataset.gp_pf_consultation_othermode = (gp_pf_other.date.count_distinct_for_patient())
+# Validation variables
+dataset.gp_pf_patient_date_total = (
+    gp_pf_condition_events.date.count_distinct_for_patient()
+)
+
+dataset.gp_pf_patient_date_mode_sum = (
+    dataset.gp_pf_patient_date_f2f
+    + dataset.gp_pf_patient_date_online
+    + dataset.gp_pf_patient_date_telephone
+    + dataset.gp_pf_patient_date_othermode
+)
 
 ########################################################
 '''
-This section repeats the above logic to count GP consultations by consultation mode,
+This section repeats the above logic to count GP consultation patient-dates by consultation mode,
 but only for control conditions rather than PF-conditions
 
 Outputs:
-- gp_control_consultation_f2f
-- gp_control_consultation_online
-- gp_control_consultation_telephone
-- gp_control_consultation_othermode
+- gp_control_patient_date_f2f
+- gp_control_patient_date_online
+- gp_control_patient_date_telephone
+- gp_control_patient_date_othermode
+- gp_control_patient_date_total
+- gp_control_patient_date_mode_sum
 '''
 control_conditions_gp_code_set = []
 for codes in control_conditions_gp_codes.values():
@@ -345,13 +385,13 @@ for codes in control_conditions_gp_codes.values():
 gp_control_condition_events = gp_events_clean.where(
     gp_events_clean.snomedct_code.is_in(control_conditions_gp_code_set)
 )
-gp_control_condition_ids = gp_control_condition_events.consultation_id
-gp_control_condition_all_events = select_events_by_consultation_id(
-    gp_events_clean,
-    gp_control_condition_ids
-)
-
 ######### Version May 2026 #########
+# gp_control_condition_ids = gp_control_condition_events.consultation_id
+# gp_control_condition_all_events = select_events_by_consultation_id(
+#     gp_events_clean,
+#     gp_control_condition_ids
+# )
+
 # gp_control_f2f_type_events = select_events_from_codelist(
 #     gp_control_condition_all_events,
 #     codelists.gp_codelist_consultation_f2f
@@ -395,59 +435,65 @@ gp_control_condition_all_events = select_events_by_consultation_id(
 # )
 
 ######### Version June 2026: patient-date level #########
-gp_control_condition_dates = gp_control_condition_all_events.date
+# Patient-dates with consultation mode codes, from all non-PF GP events in the month
 
-f2f_dates_control = select_events_from_codelist(
-    gp_control_condition_all_events,
-    codelists.gp_codelist_consultation_f2f
-).date
+# Apply hierarchy at patient-date level: f2f > online > telephone > other
+gp_control_f2f = gp_control_condition_events.where(
+    gp_control_condition_events.date.is_in(gp_f2f_dates)
+)
 
-online_dates_control = select_events_from_codelist(
-    gp_control_condition_all_events,
-    codelists.gp_codelist_consultation_online
-).date
+gp_control_online = gp_control_condition_events.where(
+    ~gp_control_condition_events.date.is_in(gp_f2f_dates)
+    & gp_control_condition_events.date.is_in(gp_online_dates)
+)
 
-telephone_dates_control = select_events_from_codelist(
-    gp_control_condition_all_events,
-    codelists.gp_codelist_consultation_telephone
-).date
+gp_control_telephone = gp_control_condition_events.where(
+    ~gp_control_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_control_condition_events.date.is_in(gp_online_dates)
+    & gp_control_condition_events.date.is_in(gp_telephone_dates)
+)
 
-has_f2f_control = gp_control_condition_dates.is_in(f2f_dates_control)
-has_online_control = gp_control_condition_dates.is_in(online_dates_control)
-has_telephone_control = gp_control_condition_dates.is_in(telephone_dates_control)
+gp_control_other = gp_control_condition_events.where(
+    ~gp_control_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_control_condition_events.date.is_in(gp_online_dates)
+    & ~gp_control_condition_events.date.is_in(gp_telephone_dates)
+)
 
-gp_control_f2f = gp_control_condition_all_events.where(has_f2f_control)
-gp_control_online = gp_control_condition_all_events.where(~has_f2f_control & has_online_control)
-gp_control_telephone = gp_control_condition_all_events.where(~has_f2f_control & ~has_online_control & has_telephone_control)
-gp_control_other = gp_control_condition_all_events.where(~has_f2f_control & ~has_online_control & ~has_telephone_control)
+dataset.gp_control_patient_date_f2f = (gp_control_f2f.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_online = (gp_control_online.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_telephone = (gp_control_telephone.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_othermode = (gp_control_other.date.count_distinct_for_patient())
 
-dataset.gp_control_consultation_f2f = (gp_control_f2f.date.count_distinct_for_patient())
-dataset.gp_control_consultation_online = (gp_control_online.date.count_distinct_for_patient())
-dataset.gp_control_consultation_telephone = (gp_control_telephone.date.count_distinct_for_patient())
-dataset.gp_control_consultation_othermode = (gp_control_other.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_total = (gp_control_condition_events.date.count_distinct_for_patient())
+
+dataset.gp_control_patient_date_mode_sum = (
+    dataset.gp_control_patient_date_f2f
+    + dataset.gp_control_patient_date_online
+    + dataset.gp_control_patient_date_telephone
+    + dataset.gp_control_patient_date_othermode
+)
 
 ########################################################
 '''
-This section counts the number of GP consultations for each PF-related conditions and control conditions by consultation mode (excluding consultations with PF service codes)
+This section counts the number of condition-specific GP patient-dates for each PF-related conditions and control conditions by consultation mode (excluding consultations with PF service codes)
 
 Outputs:
-- gp_consultation_<name>_f2f
-- gp_consultation_<name>_online
-- gp_consultation_<name>_telephone
-- gp_consultation_<name>_othermode
+- gp_<name>_patient_date_f2f
+- gp_<name>_patient_date_online
+- gp_<name>_patient_date_telephone
+- gp_<name>_patient_date_othermode
 '''
 
 # for name, codes in pf_conditions_gp_codes.items():
 for name, codes in all_conditions_gp_codes.items():
 
-    # condition-specific events -> consultation IDs
+    # condition-specific events -> condition patient-dates
     condition_events = gp_events_clean.where(gp_events_clean.snomedct_code.is_in(codes))
-    condition_ids = condition_events.consultation_id
-
-    # retrieve all events within these consultations
-    condition_all_events = select_events_by_consultation_id(gp_events_clean,condition_ids)
-
+    
     ######### Version May 2026 #########
+    # condition_ids = condition_events.consultation_id
+    # condition_all_events = select_events_by_consultation_id(gp_events_clean,condition_ids)
+
     # # assign consultation mode
     # f2f_events = select_events_from_codelist(condition_all_events,codelists.gp_codelist_consultation_f2f)
     # online_events = select_events_from_codelist(condition_all_events,codelists.gp_codelist_consultation_online)
@@ -477,35 +523,40 @@ for name, codes in all_conditions_gp_codes.items():
     # )
 
     ######### Version June 2026: patient-date level #########
-    condition_all_dates = condition_all_events.date
+    # Apply hierarchy at patient-date level: f2f > online > telephone > other
+    condition_f2f = condition_events.where(condition_events.date.is_in(gp_f2f_dates))
 
-    f2f_dates_condition = select_events_from_codelist(
-        condition_all_events,
-        codelists.gp_codelist_consultation_f2f
-    ).date
-    online_dates_condition = select_events_from_codelist(
-        condition_all_events,
-        codelists.gp_codelist_consultation_online
-    ).date
-    telephone_dates_condition = select_events_from_codelist(
-        condition_all_events,
-        codelists.gp_codelist_consultation_telephone
-    ).date
+    condition_online = condition_events.where(
+        ~condition_events.date.is_in(gp_f2f_dates)
+        & condition_events.date.is_in(gp_online_dates)
+    )
 
-    has_f2f_condition = condition_all_dates.is_in(f2f_dates_condition)
-    has_online_condition = condition_all_dates.is_in(online_dates_condition)
-    has_telephone_condition = condition_all_dates.is_in(telephone_dates_condition)
+    condition_telephone = condition_events.where(
+        ~condition_events.date.is_in(gp_f2f_dates)
+        & ~condition_events.date.is_in(gp_online_dates)
+        & condition_events.date.is_in(gp_telephone_dates)
+    )
 
-    condition_f2f = condition_all_events.where(has_f2f_condition)
-    condition_online = condition_all_events.where(~has_f2f_condition & has_online_condition)
-    condition_telephone = condition_all_events.where(~has_f2f_condition & ~has_online_condition & has_telephone_condition)
-    condition_other = condition_all_events.where(~has_f2f_condition & ~has_online_condition & ~has_telephone_condition)
+    condition_other = condition_events.where(
+        ~condition_events.date.is_in(gp_f2f_dates)
+        & ~condition_events.date.is_in(gp_online_dates)
+        & ~condition_events.date.is_in(gp_telephone_dates)
+    )
 
-    setattr(dataset,f"gp_consultation_{name}_f2f",condition_f2f.date.count_distinct_for_patient())
-    setattr(dataset,f"gp_consultation_{name}_online",condition_online.date.count_distinct_for_patient())
-    setattr(dataset,f"gp_consultation_{name}_telephone",condition_telephone.date.count_distinct_for_patient())
-    setattr(dataset,f"gp_consultation_{name}_othermode",condition_other.date.count_distinct_for_patient())
+    setattr(dataset,f"gp_{name}_patient_date_f2f",condition_f2f.date.count_distinct_for_patient(),)
+    setattr(dataset,f"gp_{name}_patient_date_online",condition_online.date.count_distinct_for_patient(),)
+    setattr(dataset,f"gp_{name}_patient_date_telephone",condition_telephone.date.count_distinct_for_patient(),)
+    setattr(dataset,f"gp_{name}_patient_date_othermode",condition_other.date.count_distinct_for_patient(),)
 
+    setattr(dataset,f"gp_{name}_patient_date_total",condition_events.date.count_distinct_for_patient(),)
+
+    setattr(
+        dataset,f"gp_{name}_patient_date_mode_sum",
+        getattr(dataset, f"gp_{name}_patient_date_f2f")
+        + getattr(dataset, f"gp_{name}_patient_date_online")
+        + getattr(dataset, f"gp_{name}_patient_date_telephone")
+        + getattr(dataset, f"gp_{name}_patient_date_othermode"),
+    )
 
 ########################################################
 """
@@ -562,7 +613,7 @@ pregnant_this_month = dataset.pregnant.is_in(("P-E", "P-EDD", "P"))
 dataset.pregnant_this_month = pregnant_this_month
 
 # bullous_impetigo during the specific month
-bullous_impetigo_this_month = check_code_in_time_window(index_date-months(1),index_date,clinical_events,codelists.gp_snomed_codelist_bullous_impetigo)
+bullous_impetigo_this_month = check_code_in_time_window(start_date,index_date,clinical_events,codelists.gp_snomed_codelist_bullous_impetigo)
 dataset.bullous_impetigo_this_month = bullous_impetigo_this_month
 
 # recurrent_impetigo: (defined as 2 or more episodes in the same year) 

--- a/analysis/dataset_definition_patients_measures.py
+++ b/analysis/dataset_definition_patients_measures.py
@@ -31,7 +31,7 @@ Patient table key fields:
 - Appointment count: scheduled; seen.
 - PF consultation count for each condition
 - GP consultation count for each condition
-- GP consultation for each condition, by consultation mode (f2f, online, telephone, other)
+- GP condition patient-date counts by consultation mode (f2f, online, telephone, other)
 - Eligibility/clinical characteristics flag (True/False)
 
 Eligibility/clinical characteristics flag for study population denominator:
@@ -209,42 +209,55 @@ for name, codes in all_conditions_gp_codes.items():
 
 ########################################################
 '''
-This section counts the number of GP consultations for PF-related conditions by consultation mode (excluding consultations with PF service codes)
+This section counts PF-related GP condition activity by consultation mode,
+excluding consultations with general PF service codes.
 
 Key logic:
-- 'gp_events_clean' already excludes all consultations with PF service codes (pf_ids).
+- 'gp_events_clean' excludes all events belonging to consultations with general PF service codes (pf_ids).
+- The current implementation uses a patient-date-based approach for consultation mode classification.
+- The previous May 2026 implementation used consultation_id to identify all events within condition-related consultations; this has been retained below as commented-out code for reference.
 
-1. 'pf_conditions_gp_code_set' is creased, including all GP used SNOMED codes for the seven conditions 
-2. events in 'gp_events_clean' are filtered using the combined code set to identify condition-related events.
-3. consultation IDs are then extracted from events in step 2. This set of IDs represents the condition-related consultations without any PF service codes.
-4. retrieve all events within the selected consultation IDs 
-5. consultation mode is classified using specific codelists:
--- version May 2026 ---
-5.1 three sets of events are identified for each consultation type: face-to-face, online, and telephone
-5.2 consultation IDs are extracted for each type/event set
-5.3 a hierarchical assignment is applied:
-- face-to-face takes precedence
-- online excludes consultations already classified as face-to-face
-- telephone excludes consultations classified as face-to-face or online
-- remaining consultations are classified as 'othermode'
-- all counts are based on distinct consultation IDs per patient.
--- version June 2026 ---
-5.1 Consultation dates are identified from all events within condition-related consultations.
-5.2 Dates associated with f2f, online, and telephone consultation-mode codes are identified separately.
-5.3 A hierarchical assignment is applied at the patient-date level:
-- if any f2f code is recorded on a given date, the date is classified as f2f;
-- otherwise, if any online code is recorded, the date is classified as online;
-- otherwise, if any telephone code is recorded, the date is classified as telephone;
-- remaining dates are classified as othermode.
-5.4 All counts are based on distinct dates per patient.
-5.5 As a result, multiple consultations for the same patient on the same date are counted once, with consultation mode assigned according to the hierarchy:
-f2f > online > telephone > othermode.
+1. 'pf_conditions_gp_code_set' is created, including all GP SNOMED codes for the seven PF-related conditions.
+2. Events in 'gp_events_clean' are filtered using the combined code set to identify PF-related GP condition events.
+3. The dates of these condition events are used to define PF-related GP condition patient-dates.
+4. Consultation-mode codes are identified separately from all events in 'gp_events_clean'.
+5. PF-related GP condition patient-dates are classified by matching to consultation-mode patient-dates, using a hierarchical assignment.
+
+-- Version May 2026: consultation_id-based approach --
+5.1 Condition-related events were first identified using the combined PF-related GP condition codelist.
+5.2 Consultation IDs were extracted from these condition-related events.
+5.3 All events belonging to those consultation IDs were retrieved.
+5.4 Face-to-face, online, and telephone mode-code events were identified within those retrieved consultation events.
+5.5 A hierarchical assignment was applied at consultation-ID level:
+- face-to-face took precedence;
+- online excluded consultations already classified as face-to-face;
+- telephone excluded consultations already classified as face-to-face or online;
+- remaining consultations were classified as othermode.
+5.6 Counts were based on distinct consultation IDs per patient.
+
+-- Version June 2026: patient-date-based approach --
+6.1 PF-related GP condition patient-dates are identified directly from condition-specific SNOMED-coded events in 'gp_events_clean'.
+6.2 Patient-dates associated with face-to-face, online, and telephone consultation-mode codes are identified separately from all events in 'gp_events_clean'.
+6.3 A hierarchical assignment is applied to PF-related GP condition patient-dates:
+- if any face-to-face mode code is recorded for the patient on the same date, the date is classified as face-to-face;
+- otherwise, if any online mode code is recorded for the patient on the same date, the date is classified as online;
+- otherwise, if any telephone mode code is recorded for the patient on the same date, the date is classified as telephone;
+- remaining PF-related GP condition patient-dates are classified as othermode.
+6.4 Counts are based on distinct dates per patient, not distinct consultation IDs.
+6.5 Multiple PF-related GP condition events for the same patient on the same date are counted once, with consultation mode assigned according to the hierarchy:
+face-to-face > online > telephone > othermode.
 
 Outputs:
-- gp_pf_consultation_f2f
-- gp_pf_consultation_online
-- gp_pf_consultation_telephone
-- gp_pf_consultation_othermode
+- gp_pf_patient_date_f2f
+- gp_pf_patient_date_online
+- gp_pf_patient_date_telephone
+- gp_pf_patient_date_othermode
+- gp_pf_patient_date_total
+- gp_pf_patient_date_mode_sum
+
+Notes:
+- These outputs are patient-date counts, not distinct consultation-ID counts.
+- The May 2026 consultation-ID-based output variables are retained only in commented-out code for reference.
 '''
 
 pf_conditions_gp_code_set = []
@@ -252,10 +265,11 @@ for codes in pf_conditions_gp_codes.values():
     pf_conditions_gp_code_set += codes
 
 gp_pf_condition_events = gp_events_clean.where(gp_events_clean.snomedct_code.is_in(pf_conditions_gp_code_set))
-gp_pf_condition_ids = gp_pf_condition_events.consultation_id
-gp_pf_condition_all_events = select_events_by_consultation_id(gp_events_clean,gp_pf_condition_ids)
 
 ######### Version May 2026 #########
+# gp_pf_condition_ids = gp_pf_condition_events.consultation_id
+# gp_pf_condition_all_events = select_events_by_consultation_id(gp_events_clean,gp_pf_condition_ids)
+
 # gp_pf_f2f_type_events = select_events_from_codelist(
 #     gp_pf_condition_all_events,
 #     codelists.gp_codelist_consultation_f2f
@@ -297,48 +311,73 @@ gp_pf_condition_all_events = select_events_by_consultation_id(gp_events_clean,gp
 #     ).consultation_id.count_distinct_for_patient()
 # )
 
-######### Version June 2026 #########
-gp_pf_condition_dates = gp_pf_condition_all_events.date
+######### Version June 2026: patient-date level #########
+# Instead of retrieving all events linked by consultation_id, 
+# first, identify patient-dates with PF-related GP condition codes, 
+# then classify those dates according to whether any face-to-face, online, or telephone consultation mode code was recorded on the same patient-date.
 
-f2f_dates = select_events_from_codelist(
-    gp_pf_condition_all_events,
+gp_f2f_dates = select_events_from_codelist(
+    gp_events_clean,
     codelists.gp_codelist_consultation_f2f
 ).date
 
-online_dates = select_events_from_codelist(
-    gp_pf_condition_all_events,
+gp_online_dates = select_events_from_codelist(
+    gp_events_clean,
     codelists.gp_codelist_consultation_online
 ).date
 
-telephone_dates = select_events_from_codelist(
-    gp_pf_condition_all_events,
+gp_telephone_dates = select_events_from_codelist(
+    gp_events_clean,
     codelists.gp_codelist_consultation_telephone
 ).date
 
-has_f2f = gp_pf_condition_dates.is_in(f2f_dates)
-has_online = gp_pf_condition_dates.is_in(online_dates)
-has_telephone = gp_pf_condition_dates.is_in(telephone_dates)
+gp_pf_f2f = gp_pf_condition_events.where(
+    gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    )
+gp_pf_online = gp_pf_condition_events.where(
+    ~gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    & gp_pf_condition_events.date.is_in(gp_online_dates)
+    )
+gp_pf_telephone = gp_pf_condition_events.where(
+    ~gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_pf_condition_events.date.is_in(gp_online_dates)
+    & gp_pf_condition_events.date.is_in(gp_telephone_dates)
+    )
+gp_pf_other = gp_pf_condition_events.where(
+    ~gp_pf_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_pf_condition_events.date.is_in(gp_online_dates)
+    & ~gp_pf_condition_events.date.is_in(gp_telephone_dates)
+    )
 
-gp_pf_f2f = gp_pf_condition_all_events.where(has_f2f)
-gp_pf_online = gp_pf_condition_all_events.where(~has_f2f & has_online)
-gp_pf_telephone = gp_pf_condition_all_events.where(~has_f2f & ~has_online & has_telephone)
-gp_pf_other = gp_pf_condition_all_events.where(~has_f2f & ~has_online & ~has_telephone)
+dataset.gp_pf_patient_date_f2f = (gp_pf_f2f.date.count_distinct_for_patient())
+dataset.gp_pf_patient_date_online = (gp_pf_online.date.count_distinct_for_patient())
+dataset.gp_pf_patient_date_telephone = (gp_pf_telephone.date.count_distinct_for_patient())
+dataset.gp_pf_patient_date_othermode = (gp_pf_other.date.count_distinct_for_patient())
 
-dataset.gp_pf_consultation_f2f = (gp_pf_f2f.date.count_distinct_for_patient())
-dataset.gp_pf_consultation_online = (gp_pf_online.date.count_distinct_for_patient())
-dataset.gp_pf_consultation_telephone = (gp_pf_telephone.date.count_distinct_for_patient())
-dataset.gp_pf_consultation_othermode = (gp_pf_other.date.count_distinct_for_patient())
+# Validation variables
+dataset.gp_pf_patient_date_total = (
+    gp_pf_condition_events.date.count_distinct_for_patient()
+)
+
+dataset.gp_pf_patient_date_mode_sum = (
+    dataset.gp_pf_patient_date_f2f
+    + dataset.gp_pf_patient_date_online
+    + dataset.gp_pf_patient_date_telephone
+    + dataset.gp_pf_patient_date_othermode
+)
 
 ########################################################
 '''
-This section repeats the above logic to count GP consultations by consultation mode,
+This section repeats the above logic to count GP consultation patient-dates by consultation mode,
 but only for control conditions rather than PF-conditions
 
 Outputs:
-- gp_control_consultation_f2f
-- gp_control_consultation_online
-- gp_control_consultation_telephone
-- gp_control_consultation_othermode
+- gp_control_patient_date_f2f
+- gp_control_patient_date_online
+- gp_control_patient_date_telephone
+- gp_control_patient_date_othermode
+- gp_control_patient_date_total
+- gp_control_patient_date_mode_sum
 '''
 
 control_conditions_gp_code_set = []
@@ -348,12 +387,13 @@ for codes in control_conditions_gp_codes.values():
 gp_control_condition_events = gp_events_clean.where(
     gp_events_clean.snomedct_code.is_in(control_conditions_gp_code_set)
 )
-gp_control_condition_ids = gp_control_condition_events.consultation_id
-gp_control_condition_all_events = select_events_by_consultation_id(
-    gp_events_clean,
-    gp_control_condition_ids
-)
+
 ######### Version May 2026 #########
+# gp_control_condition_ids = gp_control_condition_events.consultation_id
+# gp_control_condition_all_events = select_events_by_consultation_id(
+#     gp_events_clean,
+#     gp_control_condition_ids
+# )
 # gp_control_f2f_type_events = select_events_from_codelist(
 #     gp_control_condition_all_events,
 #     codelists.gp_codelist_consultation_f2f
@@ -397,59 +437,63 @@ gp_control_condition_all_events = select_events_by_consultation_id(
 # )
 
 ######### Version June 2026: patient-date level #########
-gp_control_condition_dates = gp_control_condition_all_events.date
+# Apply hierarchy at patient-date level: f2f > online > telephone > other
+gp_control_f2f = gp_control_condition_events.where(
+    gp_control_condition_events.date.is_in(gp_f2f_dates)
+)
 
-f2f_dates_control = select_events_from_codelist(
-    gp_control_condition_all_events,
-    codelists.gp_codelist_consultation_f2f
-).date
+gp_control_online = gp_control_condition_events.where(
+    ~gp_control_condition_events.date.is_in(gp_f2f_dates)
+    & gp_control_condition_events.date.is_in(gp_online_dates)
+)
 
-online_dates_control = select_events_from_codelist(
-    gp_control_condition_all_events,
-    codelists.gp_codelist_consultation_online
-).date
+gp_control_telephone = gp_control_condition_events.where(
+    ~gp_control_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_control_condition_events.date.is_in(gp_online_dates)
+    & gp_control_condition_events.date.is_in(gp_telephone_dates)
+)
 
-telephone_dates_control = select_events_from_codelist(
-    gp_control_condition_all_events,
-    codelists.gp_codelist_consultation_telephone
-).date
+gp_control_other = gp_control_condition_events.where(
+    ~gp_control_condition_events.date.is_in(gp_f2f_dates)
+    & ~gp_control_condition_events.date.is_in(gp_online_dates)
+    & ~gp_control_condition_events.date.is_in(gp_telephone_dates)
+)
 
-has_f2f_control = gp_control_condition_dates.is_in(f2f_dates_control)
-has_online_control = gp_control_condition_dates.is_in(online_dates_control)
-has_telephone_control = gp_control_condition_dates.is_in(telephone_dates_control)
+dataset.gp_control_patient_date_f2f = (gp_control_f2f.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_online = (gp_control_online.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_telephone = (gp_control_telephone.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_othermode = (gp_control_other.date.count_distinct_for_patient())
 
-gp_control_f2f = gp_control_condition_all_events.where(has_f2f_control)
-gp_control_online = gp_control_condition_all_events.where(~has_f2f_control & has_online_control)
-gp_control_telephone = gp_control_condition_all_events.where(~has_f2f_control & ~has_online_control & has_telephone_control)
-gp_control_other = gp_control_condition_all_events.where(~has_f2f_control & ~has_online_control & ~has_telephone_control)
+dataset.gp_control_patient_date_total = (gp_control_condition_events.date.count_distinct_for_patient())
 
-dataset.gp_control_consultation_f2f = (gp_control_f2f.date.count_distinct_for_patient())
-dataset.gp_control_consultation_online = (gp_control_online.date.count_distinct_for_patient())
-dataset.gp_control_consultation_telephone = (gp_control_telephone.date.count_distinct_for_patient())
-dataset.gp_control_consultation_othermode = (gp_control_other.date.count_distinct_for_patient())
+dataset.gp_control_patient_date_mode_sum = (
+    dataset.gp_control_patient_date_f2f
+    + dataset.gp_control_patient_date_online
+    + dataset.gp_control_patient_date_telephone
+    + dataset.gp_control_patient_date_othermode
+)
 
 ########################################################
 '''
-This section counts the number of GP consultations for each PF-related conditions and control conditions by consultation mode (excluding consultations with PF service codes)
+This section counts the number of condition-specific GP patient-dates for each PF-related conditions and control conditions by consultation mode (excluding consultations with PF service codes)
 
 Outputs:
-- gp_consultation_<name>_f2f
-- gp_consultation_<name>_online
-- gp_consultation_<name>_telephone
-- gp_consultation_<name>_othermode
+- gp_<name>_patient_date_f2f
+- gp_<name>_patient_date_online
+- gp_<name>_patient_date_telephone
+- gp_<name>_patient_date_othermode
 '''
 
 # for name, codes in pf_conditions_gp_codes.items():
 for name, codes in all_conditions_gp_codes.items():
 
-    # condition-specific events -> consultation IDs
+    # condition-specific events -> condition patient-dates
     condition_events = gp_events_clean.where(gp_events_clean.snomedct_code.is_in(codes))
-    condition_ids = condition_events.consultation_id
-
-    # retrieve all events within these consultations
-    condition_all_events = select_events_by_consultation_id(gp_events_clean,condition_ids)
-
+    
     ######### Version May 2026 #########
+    # condition_ids = condition_events.consultation_id
+    # condition_all_events = select_events_by_consultation_id(gp_events_clean,condition_ids)
+
     # # assign consultation mode
     # f2f_events = select_events_from_codelist(condition_all_events,codelists.gp_codelist_consultation_f2f)
     # online_events = select_events_from_codelist(condition_all_events,codelists.gp_codelist_consultation_online)
@@ -479,34 +523,40 @@ for name, codes in all_conditions_gp_codes.items():
     # )
 
     ######### Version June 2026: patient-date level #########
-    condition_all_dates = condition_all_events.date
+    # Apply hierarchy at patient-date level: f2f > online > telephone > other
+    condition_f2f = condition_events.where(condition_events.date.is_in(gp_f2f_dates))
 
-    f2f_dates_condition = select_events_from_codelist(
-        condition_all_events,
-        codelists.gp_codelist_consultation_f2f
-    ).date
-    online_dates_condition = select_events_from_codelist(
-        condition_all_events,
-        codelists.gp_codelist_consultation_online
-    ).date
-    telephone_dates_condition = select_events_from_codelist(
-        condition_all_events,
-        codelists.gp_codelist_consultation_telephone
-    ).date
+    condition_online = condition_events.where(
+        ~condition_events.date.is_in(gp_f2f_dates)
+        & condition_events.date.is_in(gp_online_dates)
+    )
 
-    has_f2f_condition = condition_all_dates.is_in(f2f_dates_condition)
-    has_online_condition = condition_all_dates.is_in(online_dates_condition)
-    has_telephone_condition = condition_all_dates.is_in(telephone_dates_condition)
+    condition_telephone = condition_events.where(
+        ~condition_events.date.is_in(gp_f2f_dates)
+        & ~condition_events.date.is_in(gp_online_dates)
+        & condition_events.date.is_in(gp_telephone_dates)
+    )
 
-    condition_f2f = condition_all_events.where(has_f2f_condition)
-    condition_online = condition_all_events.where(~has_f2f_condition & has_online_condition)
-    condition_telephone = condition_all_events.where(~has_f2f_condition & ~has_online_condition & has_telephone_condition)
-    condition_other = condition_all_events.where(~has_f2f_condition & ~has_online_condition & ~has_telephone_condition)
+    condition_other = condition_events.where(
+        ~condition_events.date.is_in(gp_f2f_dates)
+        & ~condition_events.date.is_in(gp_online_dates)
+        & ~condition_events.date.is_in(gp_telephone_dates)
+    )
 
-    setattr(dataset,f"gp_consultation_{name}_f2f",condition_f2f.date.count_distinct_for_patient())
-    setattr(dataset,f"gp_consultation_{name}_online",condition_online.date.count_distinct_for_patient())
-    setattr(dataset,f"gp_consultation_{name}_telephone",condition_telephone.date.count_distinct_for_patient())
-    setattr(dataset,f"gp_consultation_{name}_othermode",condition_other.date.count_distinct_for_patient())
+    setattr(dataset,f"gp_{name}_patient_date_f2f",condition_f2f.date.count_distinct_for_patient(),)
+    setattr(dataset,f"gp_{name}_patient_date_online",condition_online.date.count_distinct_for_patient(),)
+    setattr(dataset,f"gp_{name}_patient_date_telephone",condition_telephone.date.count_distinct_for_patient(),)
+    setattr(dataset,f"gp_{name}_patient_date_othermode",condition_other.date.count_distinct_for_patient(),)
+
+    setattr(dataset,f"gp_{name}_patient_date_total",condition_events.date.count_distinct_for_patient(),)
+
+    setattr(
+        dataset,f"gp_{name}_patient_date_mode_sum",
+        getattr(dataset, f"gp_{name}_patient_date_f2f")
+        + getattr(dataset, f"gp_{name}_patient_date_online")
+        + getattr(dataset, f"gp_{name}_patient_date_telephone")
+        + getattr(dataset, f"gp_{name}_patient_date_othermode"),
+    )
 
 ########################################################
 """
@@ -563,7 +613,7 @@ pregnant_this_month = dataset.pregnant.is_in(("P-E", "P-EDD", "P"))
 dataset.pregnant_this_month = pregnant_this_month
 
 # bullous_impetigo during the specific month
-bullous_impetigo_this_month = check_code_in_time_window(index_date-months(1),index_date,clinical_events,codelists.gp_snomed_codelist_bullous_impetigo)
+bullous_impetigo_this_month = check_code_in_time_window(start_date,index_date,clinical_events,codelists.gp_snomed_codelist_bullous_impetigo)
 dataset.bullous_impetigo_this_month = bullous_impetigo_this_month
 
 # recurrent_impetigo: (defined as 2 or more episodes in the same year) 

--- a/analysis/validation/measures_patient_consultation_mode.py
+++ b/analysis/validation/measures_patient_consultation_mode.py
@@ -9,6 +9,7 @@ measures.define_defaults(
     # intervals=months(2).starting_on("2024-02-01")
 )
 
+# The denominator is the general eligible registered population for the interval:
 measure_base_population = (
     dataset.alive
     & dataset.registered_start
@@ -19,17 +20,29 @@ measure_base_population = (
 '''
 Checks:
 - For each condition:
-  gp_consultation_<condition>_f2f
-  + gp_consultation_<condition>_online
-  + gp_consultation_<condition>_telephone
-  + gp_consultation_<condition>_othermode
-  should equal numerator_gp_consultation_<condition>.
+  gp_<condition>_patient_date_f2f
+  + gp_<condition>_patient_date_online
+  + gp_<condition>_patient_date_telephone
+  + gp_<condition>_patient_date_othermode
+  should equal gp_<condition>_patient_date_total.
 
-- Across all conditions:
-  sum(gp_consultation_<condition>_<mode>) can be compared with gp_pf_consultation_<mode>.
+- For all PF-related GP conditions combined:
+  gp_pf_patient_date_f2f
+  + gp_pf_patient_date_online
+  + gp_pf_patient_date_telephone
+  + gp_pf_patient_date_othermode
+  should equal gp_pf_patient_date_total.
+
+- Across individual conditions:
+  sum(gp_<condition>_patient_date_<mode>) can be compared with gp_pf_patient_date_<mode>.
   If the condition-specific sum is larger, this suggests overlap between
-  condition-specific GP consultation codelists.
+  condition-specific GP codelists on the same patient-date.
+
+Notes:
+- These are patient-date counts, not distinct consultation-ID counts.
+- numerator_gp_consultation_<condition> remains a separate consultation-ID-based variable.
 '''
+
 gp_modes = [
     "f2f",
     "online",
@@ -47,26 +60,99 @@ gp_conditions = [
     "impetigo",
 ]
 
-# GP PF-related consultation counts by mode
+# gp_pf_patient_date_<mode> counts PF-related GP condition patient-dates by consultation mode
+# - distinct patient-dates with at least one PF-related GP condition code;
+# - classified by consultation mode using same-patient same-date mode codes;
+# - all seven PF-related GP conditions are combined.
 for mode in gp_modes:
     measures.define_measure(
-        name=f"gp_pf_consultation_{mode}",
-        numerator=getattr(dataset, f"gp_pf_consultation_{mode}"),
+        name=f"gp_pf_patient_date_{mode}",
+        numerator=getattr(dataset, f"gp_pf_patient_date_{mode}"),
         denominator=measure_base_population,
     )
 
+# Total number of PF-related GP condition patient-dates before mode classification.
+# This should equal the sum of the four mode-specific patient-date measures.
+measures.define_measure(
+    name="gp_pf_patient_date_total",
+    numerator=dataset.gp_pf_patient_date_total,
+    denominator=measure_base_population,
+)
+
+# Validation measure:
+# gp_pf_patient_date_f2f
+# + gp_pf_patient_date_online
+# + gp_pf_patient_date_telephone
+# + gp_pf_patient_date_othermode.
+# This should equal gp_pf_patient_date_total.
+measures.define_measure(
+    name="gp_pf_patient_date_mode_sum",
+    numerator=dataset.gp_pf_patient_date_mode_sum,
+    denominator=measure_base_population,
+)
+
+# For each PF-related condition, two types of measures are produced:
+# - original consultation totals (based on consultation ids): gp_consultation_<condition>_total
+# - patient-date counts by mode
+#   - gp_<condition>_patient_date_<mode>
+#   - gp_<condition>_patient_date_total
+#   - gp_<condition>_patient_date_mode_sum
+#   --- _total should equal _mode_sum
 for condition in gp_conditions:
-    # Total GP consultation count for this condition
+    # Original GP consultation-ID-based count for this condition
     measures.define_measure(
         name=f"gp_consultation_{condition}_total",
         numerator=getattr(dataset, f"numerator_gp_consultation_{condition}"),
         denominator=measure_base_population,
     )
 
-    # GP consultation count by mode for this condition
+    # New GP condition patient-date count for this condition
+    measures.define_measure(
+        name=f"gp_{condition}_patient_date_total",
+        numerator=getattr(dataset, f"gp_{condition}_patient_date_total"),
+        denominator=measure_base_population,
+    )
+
+    measures.define_measure(
+        name=f"gp_{condition}_patient_date_mode_sum",
+        numerator=getattr(dataset, f"gp_{condition}_patient_date_mode_sum"),
+        denominator=measure_base_population,
+    )
+
+    # GP condition patient-date count by mode
     for mode in gp_modes:
         measures.define_measure(
-            name=f"gp_consultation_{condition}_{mode}",
-            numerator=getattr(dataset, f"gp_consultation_{condition}_{mode}"),
+            name=f"gp_{condition}_patient_date_{mode}",
+            numerator=getattr(dataset, f"gp_{condition}_patient_date_{mode}"),
+            denominator=measure_base_population,
+        )
+
+control_conditions = [
+    "lowerbackpain",
+]
+
+for condition in control_conditions:
+    measures.define_measure(
+        name=f"gp_consultation_{condition}_total",
+        numerator=getattr(dataset, f"numerator_gp_consultation_{condition}"),
+        denominator=measure_base_population,
+    )
+
+    measures.define_measure(
+        name=f"gp_{condition}_patient_date_total",
+        numerator=getattr(dataset, f"gp_{condition}_patient_date_total"),
+        denominator=measure_base_population,
+    )
+
+    measures.define_measure(
+        name=f"gp_{condition}_patient_date_mode_sum",
+        numerator=getattr(dataset, f"gp_{condition}_patient_date_mode_sum"),
+        denominator=measure_base_population,
+    )
+
+    for mode in gp_modes:
+        measures.define_measure(
+            name=f"gp_{condition}_patient_date_{mode}",
+            numerator=getattr(dataset, f"gp_{condition}_patient_date_{mode}"),
             denominator=measure_base_population,
         )

--- a/analysis/validation/process_measure_consultation_mode.py
+++ b/analysis/validation/process_measure_consultation_mode.py
@@ -20,6 +20,10 @@ conditions = [
     "impetigo",
 ]
 
+control_conditions = [
+    "lowerbackpain",
+]
+
 modes = [
     "f2f",
     "online",
@@ -30,13 +34,30 @@ modes = [
 # Re-order the output csv
 measure_order = []
 for mode in modes:
-    measure_order.append(f"gp_pf_consultation_{mode}")
+    measure_order.append(f"gp_pf_patient_date_{mode}")
+measure_order.append("gp_pf_patient_date_total")
+measure_order.append("gp_pf_patient_date_mode_sum")
 
+# Condition-specific measures
 for condition in conditions:
+    # Original consultation-ID-based total
     measure_order.append(f"gp_consultation_{condition}_total")
 
+    # New patient-date-based total and validation
+    measure_order.append(f"gp_{condition}_patient_date_total")
+    measure_order.append(f"gp_{condition}_patient_date_mode_sum")
+
     for mode in modes:
-        measure_order.append(f"gp_consultation_{condition}_{mode}")
+        measure_order.append(f"gp_{condition}_patient_date_{mode}")
+
+# Control condition-specific measures
+for condition in control_conditions:
+    measure_order.append(f"gp_consultation_{condition}_total")
+    measure_order.append(f"gp_{condition}_patient_date_total")
+    measure_order.append(f"gp_{condition}_patient_date_mode_sum")
+
+    for mode in modes:
+        measure_order.append(f"gp_{condition}_patient_date_{mode}")
 
 df["measure_order"] = df["measure"].apply(
     lambda x: measure_order.index(x)
@@ -72,32 +93,123 @@ for month in months:
     overall_mode_counts = {}
 
     for mode in modes:
-        overall_mode_counts[mode] = get_value(month_df,f"gp_pf_consultation_{mode}")
+        overall_mode_counts[mode] = get_value(month_df,f"gp_pf_patient_date_{mode}")
+    overall_total = get_value(month_df, "gp_pf_patient_date_total")
+    overall_mode_sum = get_value(month_df, "gp_pf_patient_date_mode_sum")
 
     # condition-level summary
     for condition in conditions:
-        total = get_value(month_df,f"gp_consultation_{condition}_total")
+        consultation_total = get_value(
+            month_df,
+            f"gp_consultation_{condition}_total",
+        )
+
+        patient_date_total = get_value(
+            month_df,
+            f"gp_{condition}_patient_date_total",
+        )
+
+        patient_date_mode_sum_recorded = get_value(
+            month_df,
+            f"gp_{condition}_patient_date_mode_sum",
+        )
+
         mode_values = {}
 
         for mode in modes:
-            mode_values[mode] = get_value(month_df,f"gp_consultation_{condition}_{mode}")
+            mode_values[mode] = get_value(month_df,f"gp_{condition}_patient_date_{mode}")
 
-        mode_sum = sum(v for v in mode_values.values() if pd.notna(v))
+        mode_sum_calculated = sum(v for v in mode_values.values() if pd.notna(v))
 
         summary_rows.append({
             "month": month,
             "condition": condition,
-            "gp_consultation_total": total,
+            
+            "gp_consultation_total": consultation_total, # original consultation-ID-based total
+
+            "gp_patient_date_total": patient_date_total, # new patient-date-based total
+
             "f2f": mode_values["f2f"],
             "online": mode_values["online"],
             "telephone": mode_values["telephone"],
             "othermode": mode_values["othermode"],
-            "mode_sum": mode_sum,
-            "mode_sum_matches_total": (mode_sum == total
-                if pd.notna(total)
+
+            "patient_date_mode_sum_calculated": mode_sum_calculated,
+            "patient_date_mode_sum_recorded": patient_date_mode_sum_recorded,
+
+            # Validation checks
+            "calculated_mode_sum_matches_patient_date_total": (
+                mode_sum_calculated == patient_date_total
+                if pd.notna(patient_date_total)
+                else None
+            ),
+            "recorded_mode_sum_matches_patient_date_total": (
+                patient_date_mode_sum_recorded == patient_date_total
+                if pd.notna(patient_date_total)
+                else None
+            ),
+            "calculated_mode_sum_matches_recorded_mode_sum": (
+                mode_sum_calculated == patient_date_mode_sum_recorded
+                if pd.notna(patient_date_mode_sum_recorded)
                 else None
             ),
 
+            # Overall PF-related GP patient-date counts
+            "overall_gp_pf_patient_date_total": overall_total,
+            "overall_gp_pf_patient_date_mode_sum": overall_mode_sum,
+            "overall_gp_pf_f2f": overall_mode_counts["f2f"],
+            "overall_gp_pf_online": overall_mode_counts["online"],
+            "overall_gp_pf_telephone": overall_mode_counts["telephone"],
+            "overall_gp_pf_othermode": overall_mode_counts["othermode"],
+        })
+
+    # Control condition-level summary
+    for condition in control_conditions:
+        consultation_total = get_value(month_df,f"gp_consultation_{condition}_total",)
+
+        patient_date_total = get_value(month_df,f"gp_{condition}_patient_date_total",)
+
+        patient_date_mode_sum_recorded = get_value(month_df,f"gp_{condition}_patient_date_mode_sum",)
+
+        mode_values = {}
+        for mode in modes:
+            mode_values[mode] = get_value(month_df,f"gp_{condition}_patient_date_{mode}",)
+
+        mode_sum_calculated = sum(v for v in mode_values.values()if pd.notna(v))
+
+        summary_rows.append({
+            "month": month,
+            "condition": condition,
+
+            "gp_consultation_total": consultation_total,
+
+            "gp_patient_date_total": patient_date_total,
+            "f2f": mode_values["f2f"],
+            "online": mode_values["online"],
+            "telephone": mode_values["telephone"],
+            "othermode": mode_values["othermode"],
+
+            "patient_date_mode_sum_calculated": mode_sum_calculated,
+            "patient_date_mode_sum_recorded": patient_date_mode_sum_recorded,
+
+            "calculated_mode_sum_matches_patient_date_total": (
+                mode_sum_calculated == patient_date_total
+                if pd.notna(patient_date_total)
+                else None
+            ),
+            "recorded_mode_sum_matches_patient_date_total": (
+                patient_date_mode_sum_recorded == patient_date_total
+                if pd.notna(patient_date_total)
+                else None
+            ),
+            "calculated_mode_sum_matches_recorded_mode_sum": (
+                mode_sum_calculated == patient_date_mode_sum_recorded
+                if pd.notna(patient_date_mode_sum_recorded)
+                else None
+            ),
+
+            "overall_gp_pf_patient_date_total": overall_total,
+            "overall_gp_pf_patient_date_mode_sum": overall_mode_sum,
             "overall_gp_pf_f2f": overall_mode_counts["f2f"],
             "overall_gp_pf_online": overall_mode_counts["online"],
             "overall_gp_pf_telephone": overall_mode_counts["telephone"],
@@ -114,14 +226,14 @@ summary_df.to_csv(
 # Plot overall GP PF consultation counts by mode
 ########################################################
 overall_mode_measures = [
-    "gp_pf_consultation_f2f",
-    "gp_pf_consultation_online",
-    "gp_pf_consultation_telephone",
-    "gp_pf_consultation_othermode",
+    "gp_pf_patient_date_f2f",
+    "gp_pf_patient_date_online",
+    "gp_pf_patient_date_telephone",
+    "gp_pf_patient_date_othermode",
 ]
 
 plot_df = df[df["measure"].isin(overall_mode_measures)].copy()
-plot_df["mode"] = (plot_df["measure"].str.replace("gp_pf_consultation_", "", regex=False))
+plot_df["mode"] = (plot_df["measure"].str.replace("gp_pf_patient_date_", "", regex=False))
 plot_df["month"] = pd.to_datetime(plot_df["interval_start"]).dt.strftime("%Y-%m")
 plot_pivot = plot_df.pivot(
     index="mode",
@@ -130,11 +242,11 @@ plot_pivot = plot_df.pivot(
 )
 
 ax = plot_pivot.plot(kind="bar",figsize=(8, 6),)
-ax.set_ylabel("GP PF consultation count")
+ax.set_ylabel("GP PF-related condition patient-date count")
 ax.set_xlabel("Consultation mode")
-ax.set_title("GP PF consultation count by mode and month")
+ax.set_title("GP PF-related condition patient-date count by mode and month")
 
 plt.xticks(rotation=45)
 plt.tight_layout()
-plt.savefig("output/patient_measures_gp_pf_consultation_by_mode_june.png",dpi=300,)
+plt.savefig("output/patient_measures_gp_pf_patient_date_by_mode_june.png",dpi=300,)
 plt.close()

--- a/project.yaml
+++ b/project.yaml
@@ -183,7 +183,7 @@ actions:
       moderately_sensitive:
         measure_tables: output/patient_measures_consultation_mode_ordered_june.csv
         summary_tables: output/patient_measures_consultation_mode_summary_june.csv
-        consultation_mode_chart: output/patient_measures_gp_pf_consultation_by_mode_june.png
+        consultation_mode_chart: output/patient_measures_gp_pf_patient_date_by_mode_june.png
 
 #################################################################
   # Dataset definition and measures for checking snomedcode appearance for PF conditions


### PR DESCRIPTION
Updated consultation mode assignment from consultation-ID matching to a patient-date set-based approach. 
Condition patient-dates are matched against patient-date sets with f2f, online, or telephone mode codes, similar to a Venn diagram - where a patient-date falls into multiple mode sets, mode is assigned using the hierarchy: f2f > online > telephone > othermode.