### PR TITLE
updated measures for validating eligibility criteria

### DIFF
--- a/analysis/validation/measures_patient_eligibility_validation.py
+++ b/analysis/validation/measures_patient_eligibility_validation.py
@@ -25,222 +25,717 @@ pf_user_population = (
     & measure_base_population
 )
 
-age_band = case(
-    when((dataset.age >= 0) & (dataset.age < 20)).then("0-19"),
-    when((dataset.age >= 20) & (dataset.age < 40)).then("20-39"),
-    when((dataset.age >= 40) & (dataset.age < 60)).then("40-59"),
-    when((dataset.age >= 60) & (dataset.age < 80)).then("60-79"),
-    when(dataset.age >= 80).then("80+"),
-    when(dataset.age.is_null()).then("Missing"),
-)
-
-age_band_naive = case(
-    when(dataset.age < 16).then("<16"),
-    when((dataset.age >= 16) & (dataset.age <= 64)).then("16-64"),
-    when(dataset.age > 64).then("65+"),
-    when(dataset.age.is_null()).then("Missing"),
-)
 
 '''
-pregancy-related: overall, by sex and age band
+Pregnancy-related: overall, by sex and age band
+
 Checks:
 - any records with sex == "unknown"?
 - any pregnancy records among males?
-- any pregnancy records among patients aged ≤16 years?
+- any pregnancy records among patients aged <=16 years?
 '''
+age_band_pregnancy_validation = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 11).then("<11"),
+    when((dataset.age >= 11) & (dataset.age < 16)).then("11-15"),
+    when((dataset.age >= 16) & (dataset.age < 20)).then("16-19"),
+    when((dataset.age >= 20) & (dataset.age <= 40)).then("20-40"),
+    when((dataset.age >= 41) & (dataset.age <= 64)).then("41-64"),
+    when(dataset.age > 64).then("65+"),
+)
+
 measures.define_measure(
-    name="base_pop_pregnancy_category",
+    name="pregnancy_category_among_base",
     numerator=dataset.pregnant_this_month,
     denominator=measure_base_population,
     group_by={"pregnant": dataset.pregnant},
 )
+
 measures.define_measure(
-    name="pregnant_by_sex",
+    name="pregnant_this_month_among_base_by_sex_age_validation",
     numerator=dataset.pregnant_this_month,
     denominator=measure_base_population,
-    group_by={"sex": dataset.sex, "age_band": age_band_naive},
+    group_by={
+        "sex": dataset.sex,
+        "age_band_pregnancy_validation": age_band_pregnancy_validation,
+    },
 )
 
+
 '''
-impetigo-related
+For each PF condition, this validation uses two complementary perspectives:
+
+1. Among patients with a PF consultation for that condition, how many were classified as not eligible, and why?
+2. Among base population patients excluded from that condition-specific eligibility, what exclusion criteria explain the exclusion?
+
+Exclusion reasons may overlap, so their proportions do not need to sum to 100%.
+'''
+
+
+'''
+Otitis media:
+    - Inclusion: children aged 1 to 17 years old
+    - Exclusion: none
+
 Checks:
-- Bullous impetigo and recurrent impetigo should both be rare in the base population.
-- The overlap between bullous and recurrent impetigo should also be very small.
-- include_patient_impetigo should mainly reflect majority of patients.
-- Among patients excluded from include_patient_impetigo, check the exclusion reasons (may overlap so their proportions do not need to sum to 100%).
+- Among patients with at least one PF otitis media consultation, what proportion were classified as not eligible?
+- Break down apparent ineligibility by otitis-media-specific age band, particularly around the age boundaries.
 '''
-measures.define_measure(
-    name="base_pop_bullous_impetigo",
-    numerator=dataset.bullous_impetigo_this_month,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="base_pop_recurrent_impetigo",
-    numerator=dataset.recurrent_impetigo_this_year,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="base_pop_bullous_and_recurrent_impetigo",
-    numerator=dataset.bullous_impetigo_this_month & dataset.recurrent_impetigo_this_year,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="pf_impetigo_eligible_among_base",
-    numerator=dataset.include_patient_impetigo,
-    denominator=measure_base_population,
-)
-pf_impetigo_excluded_population = (
-    measure_base_population
-    & ~dataset.include_patient_impetigo
-)
-measures.define_measure(
-    name="pf_impetigo_excluded_due_to_bullous",
-    numerator=dataset.bullous_impetigo_this_month,
-    denominator=pf_impetigo_excluded_population,
-)
-measures.define_measure(
-    name="pf_impetigo_excluded_due_to_recurrent",
-    numerator=dataset.recurrent_impetigo_this_year,
-    denominator=pf_impetigo_excluded_population,
-)
-measures.define_measure(
-    name="pf_impetigo_excluded_due_to_pregnant_under16",
-    numerator=(
-        dataset.pregnant_this_month
-        & (dataset.age < 16)
-    ),
-    denominator=pf_impetigo_excluded_population,
+age_band_otitismedia = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 1).then("<1"),  # not eligible - lower age boundary
+    when((dataset.age >= 1) & (dataset.age < 18)).then("1-17"),  # eligible
+    when((dataset.age >= 18) & (dataset.age < 19)).then("18"),  # not eligible - upper age boundary
+    when((dataset.age >= 19) & (dataset.age <= 64)).then("19-64"),  # not eligible
+    when(dataset.age > 64).then("65+"),  # not eligible
 )
 
-
-'''
-UTI-related checks:
-- catheter_status, recurrent_uti_6m, recurrent_uti_12m, and recurrent_uti should be relatively uncommon in the base population.
-- recurrent_uti should be greater than or equal to both recurrent_uti_6m and recurrent_uti_12m.
-- include_patient_uuti should only appear among females aged 16–64.
-- Among patients not included in UTI eligibility, check the exclusion reasons - may overlap, so proportions do not need to sum to 100%.
-'''
 measures.define_measure(
-    name="base_pop_catheter_status",
-    numerator=dataset.catheter_status,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="base_pop_recurrent_uti_6m",
-    numerator=dataset.recurrent_uti_6m,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="base_pop_recurrent_uti_12m",
-    numerator=dataset.recurrent_uti_12m,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="base_pop_recurrent_uti",
-    numerator=dataset.recurrent_uti,
-    denominator=measure_base_population,
-)
-measures.define_measure(
-    name="pf_uti_eligible_among_base",
-    numerator=dataset.include_patient_uuti,
-    denominator=measure_base_population,
-    group_by={"sex": dataset.sex, "age_band": age_band_naive},
-)
-pf_uuti_excluded_population = (
-    measure_base_population
-    & ~dataset.include_patient_uuti
-)
-measures.define_measure(
-    name="pf_uti_excluded_due_to_age_sex",
-    numerator=((dataset.sex == "male")|(dataset.age<16)|(dataset.age>64)),
-    denominator=pf_uuti_excluded_population,
-)
-measures.define_measure(
-    name="pf_uti_excluded_due_to_pregnancy",
-    numerator=dataset.pregnant_this_month,
-    denominator=pf_uuti_excluded_population,
-)
-measures.define_measure(
-    name="pf_uti_excluded_due_to_catheter",
-    numerator=dataset.catheter_status,
-    denominator=pf_uuti_excluded_population,
-)
-measures.define_measure(
-    name="pf_uti_excluded_due_to_recurrent_uti",
-    numerator=dataset.recurrent_uti,
-    denominator=pf_uuti_excluded_population,
-)
-
-# PF otitis media eligible: eligible population age range >=16 should be close to zero
-measures.define_measure(
-    name="pf_otitis_media_eligible_among_base",
+    name="otitismedia_eligible_among_base",
     numerator=dataset.include_patient_otitis_media,
     denominator=measure_base_population,
-    group_by={"age_band": age_band_naive},
+    group_by={"age_band_otitismedia": age_band_otitismedia},
 )
 
-# PF sinusitis eligible: eligible population age range <16 should be close to zero
 measures.define_measure(
-    name="pf_sinusitis_eligible_among_base",
+    name="otitismedia_excluded_among_base_by_age_band",
+    numerator=~dataset.include_patient_otitis_media,
+    denominator=measure_base_population,
+    group_by={"age_band_otitismedia": age_band_otitismedia},
+)
+
+otitismedia_pf_user_population = (
+    (dataset.numerator_pf_consultation_otitismedia > 0)
+    & measure_base_population
+)
+
+measures.define_measure(
+    name="otitismedia_pf_users_not_eligible",
+    numerator=~dataset.include_patient_otitis_media,
+    denominator=otitismedia_pf_user_population,
+)
+
+measures.define_measure(
+    name="otitismedia_pf_users_not_eligible_by_age_band",
+    numerator=~dataset.include_patient_otitis_media,
+    denominator=otitismedia_pf_user_population,
+    group_by={"age_band_otitismedia": age_band_otitismedia},
+)
+
+
+'''
+Sinusitis:
+    - Inclusion: age >= 12
+    - Exclusion: none
+
+Checks:
+- Among patients with at least one PF sinusitis consultation, what proportion were classified as not eligible?
+- Break down apparent ineligibility by sinusitis-specific age band, particularly around the age boundary.
+'''
+age_band_sinusitis = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 1).then("<1"),  # not eligible
+    when((dataset.age >= 1) & (dataset.age < 11)).then("1-10"),  # not eligible
+    when((dataset.age >= 11) & (dataset.age < 12)).then("11"),  # not eligible - age boundary
+    when((dataset.age >= 12) & (dataset.age <= 64)).then("12-64"),  # eligible
+    when(dataset.age > 64).then("65+"),  # eligible
+)
+
+measures.define_measure(
+    name="sinusitis_eligible_among_base",
     numerator=dataset.include_patient_sinusitis,
     denominator=measure_base_population,
-    group_by={"age_band": age_band_naive},
+    group_by={"age_band_sinusitis": age_band_sinusitis},
 )
 
-# PF sore throat eligible
 measures.define_measure(
-    name="pf_sore_throat_eligible_among_base",
+    name="sinusitis_excluded_among_base_by_age_band",
+    numerator=~dataset.include_patient_sinusitis,
+    denominator=measure_base_population,
+    group_by={"age_band_sinusitis": age_band_sinusitis},
+)
+
+sinusitis_pf_user_population = (
+    (dataset.numerator_pf_consultation_sinusitis > 0)
+    & measure_base_population
+)
+
+measures.define_measure(
+    name="sinusitis_pf_users_not_eligible",
+    numerator=~dataset.include_patient_sinusitis,
+    denominator=sinusitis_pf_user_population,
+)
+
+measures.define_measure(
+    name="sinusitis_pf_users_not_eligible_by_age_band",
+    numerator=~dataset.include_patient_sinusitis,
+    denominator=sinusitis_pf_user_population,
+    group_by={"age_band_sinusitis": age_band_sinusitis},
+)
+
+
+'''
+Sore throat:
+    - Inclusion: age >= 5
+    - Exclusion: pregnant female under 16s
+
+Checks:
+- Among patients with at least one PF sore throat consultation, what proportion were classified as not eligible?
+- Break down apparent ineligibility by age band and pregnancy-related exclusion.
+'''
+age_band_sorethroat = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 1).then("<1"),  # not eligible
+    when((dataset.age >= 1) & (dataset.age < 4)).then("1-3"),  # not eligible
+    when((dataset.age >= 4) & (dataset.age < 5)).then("4"),  # not eligible - age boundary
+    when((dataset.age >= 5) & (dataset.age < 16)).then("5-15"),  # eligible by age, relevant for pregnancy exclusion
+    when((dataset.age >= 16) & (dataset.age < 17)).then("16"),  # eligible by age, useful boundary check
+    when((dataset.age >= 17) & (dataset.age <= 64)).then("17-64"),  # eligible by age
+    when(dataset.age > 64).then("65+"),  # eligible by age
+)
+
+measures.define_measure(
+    name="sorethroat_eligible_among_base",
     numerator=dataset.include_patient_sore_throat,
     denominator=measure_base_population,
+    group_by={"age_band_sorethroat": age_band_sorethroat},
 )
-sore_throat_excluded_population = (
+
+sorethroat_excluded_population = (
     measure_base_population
     & ~dataset.include_patient_sore_throat
 )
+
 measures.define_measure(
-    name="pf_sore_throat_excluded_due_to_age_under5",
-    numerator=(dataset.age < 5),
-    denominator=sore_throat_excluded_population,
-)
-measures.define_measure(
-    name="pf_sore_throat_excluded_due_to_pregnant_under16",
-    numerator=(dataset.pregnant_this_month & (dataset.age < 16)),
-    denominator=sore_throat_excluded_population,
+    name="sorethroat_excluded_among_base_by_age_band",
+    numerator=~dataset.include_patient_sore_throat,
+    denominator=measure_base_population,
+    group_by={"age_band_sorethroat": age_band_sorethroat},
 )
 
-# PF infected insect bites eligible
 measures.define_measure(
-    name="pf_insect_bite_eligible_among_base",
+    name="sorethroat_excluded_among_base_due_to_pregnant_female_under16",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+        & (dataset.age < 16)
+    ),
+    denominator=sorethroat_excluded_population,
+)
+
+sorethroat_pf_user_population = (
+    (dataset.numerator_pf_consultation_sorethroat > 0)
+    & measure_base_population
+)
+
+measures.define_measure(
+    name="sorethroat_pf_users_not_eligible",
+    numerator=~dataset.include_patient_sore_throat,
+    denominator=sorethroat_pf_user_population,
+)
+
+measures.define_measure(
+    name="sorethroat_pf_users_not_eligible_by_age_band",
+    numerator=~dataset.include_patient_sore_throat,
+    denominator=sorethroat_pf_user_population,
+    group_by={"age_band_sorethroat": age_band_sorethroat},
+)
+
+measures.define_measure(
+    name="sorethroat_pf_users_not_eligible_by_sex_age_pregnancy",
+    numerator=~dataset.include_patient_sore_throat,
+    denominator=sorethroat_pf_user_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_sorethroat": age_band_sorethroat,
+        "pregnant": dataset.pregnant,
+    },
+)
+
+
+'''
+Insect bites:
+    - Inclusion: age >= 1
+    - Exclusion: pregnant female under 16s
+
+Checks:
+- Among patients with at least one PF insect bite consultation, what proportion were classified as not eligible?
+- Break down apparent ineligibility by age band and pregnancy-related exclusion.
+'''
+age_band_insectbite = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 1).then("<1"),  # not eligible
+    when((dataset.age >= 1) & (dataset.age < 16)).then("1-15"),  # eligible by age, relevant for pregnancy exclusion
+    when((dataset.age >= 16) & (dataset.age < 17)).then("16"),  # eligible by age, useful boundary check
+    when((dataset.age >= 17) & (dataset.age <= 64)).then("17-64"),  # eligible by age
+    when(dataset.age > 64).then("65+"),  # eligible by age
+)
+
+measures.define_measure(
+    name="insectbite_eligible_among_base",
     numerator=dataset.include_patient_insect_bites,
     denominator=measure_base_population,
+    group_by={"age_band_insectbite": age_band_insectbite},
 )
 
-# PF shingle eligible
+insectbite_excluded_population = (
+    measure_base_population
+    & ~dataset.include_patient_insect_bites
+)
+
 measures.define_measure(
-    name="pf_shingles_eligible_among_base",
+    name="insectbite_excluded_among_base_by_age_band",
+    numerator=~dataset.include_patient_insect_bites,
+    denominator=measure_base_population,
+    group_by={"age_band_insectbite": age_band_insectbite},
+)
+
+measures.define_measure(
+    name="insectbite_excluded_among_base_due_to_pregnant_female_under16",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+        & (dataset.age < 16)
+    ),
+    denominator=insectbite_excluded_population,
+)
+
+insectbite_pf_user_population = (
+    (dataset.numerator_pf_consultation_insectbite > 0)
+    & measure_base_population
+)
+
+measures.define_measure(
+    name="insectbite_pf_users_not_eligible",
+    numerator=~dataset.include_patient_insect_bites,
+    denominator=insectbite_pf_user_population,
+)
+
+measures.define_measure(
+    name="insectbite_pf_users_not_eligible_by_age_band",
+    numerator=~dataset.include_patient_insect_bites,
+    denominator=insectbite_pf_user_population,
+    group_by={"age_band_insectbite": age_band_insectbite},
+)
+
+measures.define_measure(
+    name="insectbite_pf_users_not_eligible_by_sex_age_pregnancy",
+    numerator=~dataset.include_patient_insect_bites,
+    denominator=insectbite_pf_user_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_insectbite": age_band_insectbite,
+        "pregnant": dataset.pregnant,
+    },
+)
+
+
+'''
+Shingles:
+    - Inclusion: age >= 18
+    - Exclusion: pregnant female
+
+Checks:
+- Among patients with at least one PF shingles consultation, what proportion were classified as not eligible?
+- Break down apparent ineligibility by age band and pregnancy-related exclusion.
+'''
+age_band_shingles = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 1).then("<1"),  # not eligible
+    when((dataset.age >= 1) & (dataset.age < 17)).then("1-16"),  # not eligible
+    when((dataset.age >= 17) & (dataset.age < 18)).then("17"),  # not eligible - age boundary
+    when((dataset.age >= 18) & (dataset.age <= 64)).then("18-64"),  # eligible by age
+    when(dataset.age > 64).then("65+"),  # eligible by age
+)
+
+measures.define_measure(
+    name="shingles_eligible_among_base",
     numerator=dataset.include_patient_shingles,
     denominator=measure_base_population,
-    group_by={"age_band": age_band_naive},
+    group_by={"age_band_shingles": age_band_shingles},
 )
+
 shingles_excluded_population = (
     measure_base_population
     & ~dataset.include_patient_shingles
 )
+
 measures.define_measure(
-    name="pf_shingles_excluded_due_to_age_under18",
-    numerator=(dataset.age < 18),
-    denominator=shingles_excluded_population,
+    name="shingles_excluded_among_base_by_age_band",
+    numerator=~dataset.include_patient_shingles,
+    denominator=measure_base_population,
+    group_by={"age_band_shingles": age_band_shingles},
 )
+
 measures.define_measure(
-    name="pf_shingles_excluded_due_to_pregnancy",
-    numerator=dataset.pregnant_this_month,
+    name="shingles_excluded_among_base_due_to_pregnant_female",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+    ),
     denominator=shingles_excluded_population,
 )
 
-# include_patient_overall_eligible
+shingles_pf_user_population = (
+    (dataset.numerator_pf_consultation_shingles > 0)
+    & measure_base_population
+)
+
+shingles_pf_user_not_eligible_population = (
+    shingles_pf_user_population
+    & ~dataset.include_patient_shingles
+)
+
+measures.define_measure(
+    name="shingles_pf_users_not_eligible",
+    numerator=~dataset.include_patient_shingles,
+    denominator=shingles_pf_user_population,
+)
+
+measures.define_measure(
+    name="shingles_pf_users_not_eligible_by_age_band",
+    numerator=~dataset.include_patient_shingles,
+    denominator=shingles_pf_user_population,
+    group_by={"age_band_shingles": age_band_shingles},
+)
+
+measures.define_measure(
+    name="shingles_pf_users_not_eligible_due_to_pregnant_female",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+    ),
+    denominator=shingles_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="shingles_pf_users_not_eligible_by_sex_age_pregnancy",
+    numerator=~dataset.include_patient_shingles,
+    denominator=shingles_pf_user_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_shingles": age_band_shingles,
+        "pregnant": dataset.pregnant,
+    },
+)
+
+
+'''
+Impetigo:
+    - Inclusion: age >= 1
+    - Exclusion:
+        - Bullous impetigo
+        - Recurrent impetigo
+        - Pregnant female under 16s
+
+Checks:
+- Bullous impetigo and recurrent impetigo should both be rare in the base population.
+- The overlap between bullous and recurrent impetigo should also be very small.
+- include_patient_impetigo should mainly reflect the majority of patients.
+- Among patients with at least one PF impetigo consultation who were classified as not eligible, check the exclusion reasons.
+'''
+measures.define_measure(
+    name="bullous_impetigo_among_base",
+    numerator=dataset.bullous_impetigo_this_month,
+    denominator=measure_base_population,
+)
+
+measures.define_measure(
+    name="recurrent_impetigo_among_base",
+    numerator=dataset.recurrent_impetigo_this_year,
+    denominator=measure_base_population,
+)
+
+measures.define_measure(
+    name="bullous_and_recurrent_impetigo_among_base",
+    numerator=dataset.bullous_impetigo_this_month & dataset.recurrent_impetigo_this_year,
+    denominator=measure_base_population,
+)
+
+age_band_impetigo = age_band_insectbite
+
+measures.define_measure(
+    name="impetigo_eligible_among_base",
+    numerator=dataset.include_patient_impetigo,
+    denominator=measure_base_population,
+    group_by={"age_band_impetigo": age_band_impetigo},
+)
+
+impetigo_excluded_population = (
+    measure_base_population
+    & ~dataset.include_patient_impetigo
+)
+
+measures.define_measure(
+    name="impetigo_excluded_among_base_by_age_band",
+    numerator=~dataset.include_patient_impetigo,
+    denominator=measure_base_population,
+    group_by={"age_band_impetigo": age_band_impetigo},
+)
+
+measures.define_measure(
+    name="impetigo_excluded_among_base_due_to_bullous",
+    numerator=dataset.bullous_impetigo_this_month,
+    denominator=impetigo_excluded_population,
+)
+
+measures.define_measure(
+    name="impetigo_excluded_among_base_due_to_recurrent",
+    numerator=dataset.recurrent_impetigo_this_year,
+    denominator=impetigo_excluded_population,
+)
+
+measures.define_measure(
+    name="impetigo_excluded_among_base_due_to_pregnant_female_under16",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+        & (dataset.age < 16)
+    ),
+    denominator=impetigo_excluded_population,
+)
+
+impetigo_pf_user_population = (
+    (dataset.numerator_pf_consultation_impetigo > 0)
+    & measure_base_population
+)
+
+impetigo_pf_user_not_eligible_population = (
+    impetigo_pf_user_population
+    & ~dataset.include_patient_impetigo
+)
+
+measures.define_measure(
+    name="impetigo_pf_users_not_eligible",
+    numerator=~dataset.include_patient_impetigo,
+    denominator=impetigo_pf_user_population,
+)
+
+measures.define_measure(
+    name="impetigo_pf_users_not_eligible_by_age_band",
+    numerator=~dataset.include_patient_impetigo,
+    denominator=impetigo_pf_user_population,
+    group_by={"age_band_impetigo": age_band_impetigo},
+)
+
+measures.define_measure(
+    name="impetigo_pf_users_not_eligible_due_to_bullous",
+    numerator=dataset.bullous_impetigo_this_month,
+    denominator=impetigo_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="impetigo_pf_users_not_eligible_due_to_recurrent",
+    numerator=dataset.recurrent_impetigo_this_year,
+    denominator=impetigo_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="impetigo_pf_users_not_eligible_due_to_pregnant_female_under16",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+        & (dataset.age < 16)
+    ),
+    denominator=impetigo_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="impetigo_pf_users_not_eligible_by_sex_age_pregnancy",
+    numerator=~dataset.include_patient_impetigo,
+    denominator=impetigo_pf_user_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_impetigo": age_band_impetigo,
+        "pregnant": dataset.pregnant,
+    },
+)
+
+
+'''
+UTI:
+    - Inclusion: women aged 16 to 64 years
+    - Exclusion:
+        - Pregnant female
+        - Urinary catheter
+        - Recurrent UTI
+
+Checks:
+- catheter_status, recurrent_uti_6m, recurrent_uti_12m, and recurrent_uti should be relatively uncommon in the base population.
+- recurrent_uti should be greater than or equal to both recurrent_uti_6m and recurrent_uti_12m.
+- include_patient_uuti should only appear among females aged 16-64.
+- Among base population patients excluded from UTI eligibility, check the exclusion reasons.
+- Among patients with at least one PF UTI consultation who were classified as not eligible, check the exclusion reasons.
+'''
+age_band_uti = case(
+    when(dataset.age.is_null()).then("Missing"),
+    when(dataset.age < 1).then("<1"),  # not eligible
+    when((dataset.age >= 1) & (dataset.age < 15)).then("1-14"),  # not eligible
+    when((dataset.age >= 15) & (dataset.age < 16)).then("15"),  # not eligible - lower age boundary
+    when((dataset.age >= 16) & (dataset.age <= 64)).then("16-64"),  # eligible age range
+    when((dataset.age >= 65) & (dataset.age < 66)).then("65"),  # not eligible - upper age boundary
+    when(dataset.age > 65).then("66+"),  # not eligible
+)
+
+measures.define_measure(
+    name="catheter_status_among_base",
+    numerator=dataset.catheter_status,
+    denominator=measure_base_population,
+)
+
+measures.define_measure(
+    name="recurrent_uti_6m_among_base",
+    numerator=dataset.recurrent_uti_6m,
+    denominator=measure_base_population,
+)
+
+measures.define_measure(
+    name="recurrent_uti_12m_among_base",
+    numerator=dataset.recurrent_uti_12m,
+    denominator=measure_base_population,
+)
+
+measures.define_measure(
+    name="recurrent_uti_among_base",
+    numerator=dataset.recurrent_uti,
+    denominator=measure_base_population,
+)
+
+measures.define_measure(
+    name="uti_eligible_among_base",
+    numerator=dataset.include_patient_uuti,
+    denominator=measure_base_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_uti": age_band_uti,
+    },
+)
+
+uti_excluded_population = (
+    measure_base_population
+    & ~dataset.include_patient_uuti
+)
+
+measures.define_measure(
+    name="uti_excluded_among_base_by_sex_age_band",
+    numerator=~dataset.include_patient_uuti,
+    denominator=measure_base_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_uti": age_band_uti,
+    },
+)
+
+measures.define_measure(
+    name="uti_excluded_among_base_due_to_age_sex",
+    numerator=~(
+        (dataset.sex == "female")
+        & (dataset.age >= 16)
+        & (dataset.age <= 64)
+    ),
+    denominator=uti_excluded_population,
+)
+
+measures.define_measure(
+    name="uti_excluded_among_base_due_to_pregnant_female",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+    ),
+    denominator=uti_excluded_population,
+)
+
+measures.define_measure(
+    name="uti_excluded_among_base_due_to_catheter",
+    numerator=dataset.catheter_status,
+    denominator=uti_excluded_population,
+)
+
+measures.define_measure(
+    name="uti_excluded_among_base_due_to_recurrent_uti",
+    numerator=dataset.recurrent_uti,
+    denominator=uti_excluded_population,
+)
+
+uti_pf_user_population = (
+    (dataset.numerator_pf_consultation_uti > 0)
+    & measure_base_population
+)
+
+uti_pf_user_not_eligible_population = (
+    uti_pf_user_population
+    & ~dataset.include_patient_uuti
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible",
+    numerator=~dataset.include_patient_uuti,
+    denominator=uti_pf_user_population,
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible_by_sex_age_band",
+    numerator=~dataset.include_patient_uuti,
+    denominator=uti_pf_user_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_uti": age_band_uti,
+    },
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible_due_to_age_sex",
+    numerator=~(
+        (dataset.sex == "female")
+        & (dataset.age >= 16)
+        & (dataset.age <= 64)
+    ),
+    denominator=uti_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible_due_to_pregnant_female",
+    numerator=(
+        dataset.pregnant_this_month
+        & (dataset.sex == "female")
+    ),
+    denominator=uti_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible_due_to_catheter",
+    numerator=dataset.catheter_status,
+    denominator=uti_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible_due_to_recurrent_uti",
+    numerator=dataset.recurrent_uti,
+    denominator=uti_pf_user_not_eligible_population,
+)
+
+measures.define_measure(
+    name="uti_pf_users_not_eligible_by_sex_age_pregnancy",
+    numerator=~dataset.include_patient_uuti,
+    denominator=uti_pf_user_population,
+    group_by={
+        "sex": dataset.sex,
+        "age_band_uti": age_band_uti,
+        "pregnant": dataset.pregnant,
+    },
+)
+
+
+# Overall PF eligibility
 measures.define_measure(
     name="pf_overall_eligible_among_base",
     numerator=dataset.include_patient_overall_eligible,
     denominator=measure_base_population,
-    group_by={"age_band": age_band_naive},
+    group_by={"age_band_pregnancy_validation": age_band_pregnancy_validation},
+)
+
+measures.define_measure(
+    name="pf_overall_user_not_eligible",
+    numerator=~dataset.include_patient_overall_eligible,
+    denominator=pf_user_population,
 )

--- a/analysis/validation/process_measure_eligibility_validation.py
+++ b/analysis/validation/process_measure_eligibility_validation.py
@@ -1,37 +1,3 @@
-# Condition: acute otitis media
-# - inclusion: children aged 1 to 17 years
-# - exclusion: none
-
-# Condition: acute sinusitis
-# - inclusion: age >= 12
-# - exclusion: none
-
-# Condition: acute sore throat
-# - inclusion: age >= 5
-# - exclusion: pregnant individuals under 16s
-
-# Condition: infected insect bites
-# - inclusion: age >= 1
-# - exclusion: pregnant individuals under 16s
-
-# Condition: shingles
-# - inclusion: age >= 18
-# - exclusion: pregnant individuals
-
-# Condition: impetigo
-# - inclusion: age >= 1
-# - exclusion: 
-# - - bullous impetigo, 
-# - - recurrent impetigo (defined as 2 or more episodes in the same year), 
-# - - pregnant individuals under 16 years
-
-# Condition: Uncomplicated UTI
-# - inclusion: women aged 16 to 64 years
-# - exclusion: 
-# - - pregnant individuals
-# - - urinary catheter
-# - - recurrent UTI: 2 episodes in last 6 months, or 3 episodes in last 12 months
-
 import pandas as pd
 
 input_file = "output/patient_measures_eligibility_validation.csv"
@@ -41,69 +7,152 @@ df = pd.read_csv(input_file)
 
 measure_order = [
     # Pregnancy-related
-    "base_pop_pregnancy_category",
-    "pregnant_by_sex",
-
-    # Impetigo-related
-    "base_pop_bullous_impetigo",
-    "base_pop_recurrent_impetigo",
-    "base_pop_bullous_and_recurrent_impetigo",
-    "pf_impetigo_eligible_among_base",
-    "pf_impetigo_excluded_due_to_bullous",
-    "pf_impetigo_excluded_due_to_recurrent",
-    "pf_impetigo_excluded_due_to_pregnant_under16",
-
-    # UTI-related
-    "base_pop_catheter_status",
-    "base_pop_recurrent_uti_6m",
-    "base_pop_recurrent_uti_12m",
-    "base_pop_recurrent_uti",
-    "pf_uti_eligible_among_base",
-    "pf_uti_excluded_due_to_age_sex",
-    "pf_uti_excluded_due_to_pregnancy",
-    "pf_uti_excluded_due_to_catheter",
-    "pf_uti_excluded_due_to_recurrent_uti",
+    "pregnancy_category_among_base",
+    "pregnant_this_month_among_base_by_sex_age_validation",
 
     # Otitis media
-    "pf_otitis_media_eligible_among_base",
+    "otitismedia_eligible_among_base",
+    "otitismedia_excluded_among_base_by_age_band",
+    "otitismedia_pf_users_not_eligible",
+    "otitismedia_pf_users_not_eligible_by_age_band",
 
     # Sinusitis
-    "pf_sinusitis_eligible_among_base",
+    "sinusitis_eligible_among_base",
+    "sinusitis_excluded_among_base_by_age_band",
+    "sinusitis_pf_users_not_eligible",
+    "sinusitis_pf_users_not_eligible_by_age_band",
 
     # Sore throat
-    "pf_sore_throat_eligible_among_base",
-    "pf_sore_throat_excluded_due_to_age_under5",
-    "pf_sore_throat_excluded_due_to_pregnant_under16",
+    "sorethroat_eligible_among_base",
+    "sorethroat_excluded_among_base_by_age_band",
+    "sorethroat_excluded_among_base_due_to_pregnant_female_under16",
+    "sorethroat_pf_users_not_eligible",
+    "sorethroat_pf_users_not_eligible_by_age_band",
+    "sorethroat_pf_users_not_eligible_by_sex_age_pregnancy",
 
     # Insect bites
-    "pf_insect_bite_eligible_among_base",
+    "insectbite_eligible_among_base",
+    "insectbite_excluded_among_base_by_age_band",
+    "insectbite_excluded_among_base_due_to_pregnant_female_under16",
+    "insectbite_pf_users_not_eligible",
+    "insectbite_pf_users_not_eligible_by_age_band",
+    "insectbite_pf_users_not_eligible_by_sex_age_pregnancy",
 
     # Shingles
-    "pf_shingles_eligible_among_base",
-    "pf_shingles_excluded_due_to_age_under18",
-    "pf_shingles_excluded_due_to_pregnancy",
+    "shingles_eligible_among_base",
+    "shingles_excluded_among_base_by_age_band",
+    "shingles_excluded_among_base_due_to_pregnant_female",
+    "shingles_pf_users_not_eligible",
+    "shingles_pf_users_not_eligible_by_age_band",
+    "shingles_pf_users_not_eligible_due_to_pregnant_female",
+    "shingles_pf_users_not_eligible_by_sex_age_pregnancy",
+
+    # Impetigo
+    "bullous_impetigo_among_base",
+    "recurrent_impetigo_among_base",
+    "bullous_and_recurrent_impetigo_among_base",
+    "impetigo_eligible_among_base",
+    "impetigo_excluded_among_base_by_age_band",
+    "impetigo_excluded_among_base_due_to_bullous",
+    "impetigo_excluded_among_base_due_to_recurrent",
+    "impetigo_excluded_among_base_due_to_pregnant_female_under16",
+    "impetigo_pf_users_not_eligible",
+    "impetigo_pf_users_not_eligible_by_age_band",
+    "impetigo_pf_users_not_eligible_due_to_bullous",
+    "impetigo_pf_users_not_eligible_due_to_recurrent",
+    "impetigo_pf_users_not_eligible_due_to_pregnant_female_under16",
+    "impetigo_pf_users_not_eligible_by_sex_age_pregnancy",
+
+    # UTI
+    "catheter_status_among_base",
+    "recurrent_uti_6m_among_base",
+    "recurrent_uti_12m_among_base",
+    "recurrent_uti_among_base",
+    "uti_eligible_among_base",
+    "uti_excluded_among_base_by_sex_age_band",
+    "uti_excluded_among_base_due_to_age_sex",
+    "uti_excluded_among_base_due_to_pregnant_female",
+    "uti_excluded_among_base_due_to_catheter",
+    "uti_excluded_among_base_due_to_recurrent_uti",
+    "uti_pf_users_not_eligible",
+    "uti_pf_users_not_eligible_by_sex_age_band",
+    "uti_pf_users_not_eligible_due_to_age_sex",
+    "uti_pf_users_not_eligible_due_to_pregnant_female",
+    "uti_pf_users_not_eligible_due_to_catheter",
+    "uti_pf_users_not_eligible_due_to_recurrent_uti",
+    "uti_pf_users_not_eligible_by_sex_age_pregnancy",
 
     # Overall eligible
     "pf_overall_eligible_among_base",
+    "pf_overall_user_not_eligible",
 ]
 
-df["measure_order"] = df["measure"].apply(
-    lambda x: measure_order.index(x) if x in measure_order else 999
+measure_rank = {measure: i for i, measure in enumerate(measure_order)}
+
+df["measure_order"] = (
+    df["measure"]
+    .map(measure_rank)
+    .fillna(999)
+    .astype(int)
 )
+
+# Combine condition-specific age-band columns into one display column.
+age_band_cols = [
+    "age_band_pregnancy_validation",
+    "age_band_otitismedia",
+    "age_band_sinusitis",
+    "age_band_sorethroat",
+    "age_band_insectbite",
+    "age_band_shingles",
+    "age_band_impetigo",
+    "age_band_uti",
+]
+
+existing_age_band_cols = [col for col in age_band_cols if col in df.columns]
+
+if existing_age_band_cols:
+    df["age_band"] = (
+        df[existing_age_band_cols]
+        .bfill(axis=1)
+        .iloc[:, 0]
+    )
+    df = df.drop(columns=existing_age_band_cols)
 
 sort_cols = ["measure_order", "measure", "interval_start"]
 
-if "sex" in df.columns:
-    sort_cols.append("sex")
-
-if "age_band" in df.columns:
-    sort_cols.append("age_band")
-
-if "pregnant" in df.columns:
-    sort_cols.append("pregnant")
+for col in ["sex", "age_band", "pregnant"]:
+    if col in df.columns:
+        sort_cols.append(col)
 
 df = df.sort_values(sort_cols).drop(columns=["measure_order"])
 
+# Optional: put commonly reviewed columns near the front
+front_cols = [
+    "measure",
+    "interval_start",
+    "interval_end",
+    "sex",
+    "age_band",
+    "pregnant",
+    "numerator",
+    "denominator",
+    "value",
+]
+
+front_cols = [col for col in front_cols if col in df.columns]
+other_cols = [col for col in df.columns if col not in front_cols]
+df = df[front_cols + other_cols]
+
 df.to_csv(output_file, index=False)
 
+unknown_measures = sorted(set(df["measure"]) - set(measure_order))
+
 print(f"Saved ordered measures to {output_file}")
+
+if unknown_measures:
+    print(
+        "Warning: the following measures were not included in measure_order "
+        "and were placed at the end:"
+    )
+    for measure in unknown_measures:
+        print(f"- {measure}")


### PR DESCRIPTION
Updated the patient eligibility validation measures and post-processing script.

Changes:
- Added pregnancy validation by sex and age band to assess potential false-positive pregnancy flags.
- Added condition-specific eligibility validation measures for each Pharmacy First condition.
- Added checks for PF users classified as not eligible, with condition-specific age-band and relevant exclusion-reason breakdowns.
- Updated the ordering script to sort the new measure names.