### PR TITLE
pregnancy flag - exclude age 11 and under

### DIFF
--- a/analysis/dataset_definition_patients.py
+++ b/analysis/dataset_definition_patients.py
@@ -609,7 +609,9 @@ dataset.pregnant = case(
     # recent pregnancy code
     when(dataset.pregnancy_code.is_not_null()).then("P"),
     otherwise="0",)
-pregnant_this_month = dataset.pregnant.is_in(("P-E", "P-EDD", "P"))
+# pregnant_this_month = dataset.pregnant.is_in(("P-E", "P-EDD", "P"))
+# Age <= 11: pregnancy flags are considered too unreliable and are not counted as pregnant.
+pregnant_this_month = (dataset.pregnant.is_in(("P-E", "P-EDD", "P")) & (age >= 12))
 dataset.pregnant_this_month = pregnant_this_month
 
 # bullous_impetigo during the specific month

--- a/analysis/dataset_definition_patients_measures.py
+++ b/analysis/dataset_definition_patients_measures.py
@@ -609,7 +609,9 @@ dataset.pregnant = case(
     # recent pregnancy code
     when(dataset.pregnancy_code.is_not_null()).then("P"),
     otherwise="0",)
-pregnant_this_month = dataset.pregnant.is_in(("P-E", "P-EDD", "P"))
+# pregnant_this_month = dataset.pregnant.is_in(("P-E", "P-EDD", "P"))
+# Age <= 11: pregnancy flags are considered too unreliable and are not counted as pregnant.
+pregnant_this_month = (dataset.pregnant.is_in(("P-E", "P-EDD", "P")) & (age >= 12))
 dataset.pregnant_this_month = pregnant_this_month
 
 # bullous_impetigo during the specific month


### PR DESCRIPTION
Patients aged 11 or under are excluded from the pregnancy definition due to concerns about unreliable pregnancy flags in very young age groups. 