### PR TITLE
Pregnancy refinement

### DIFF
--- a/analysis/check_pregnancy_variables/dataset_definition_pregnancy_measures.py
+++ b/analysis/check_pregnancy_variables/dataset_definition_pregnancy_measures.py
@@ -7,9 +7,9 @@ start_date = "2023-05-01"
 #end_date = "2024-08-31"
 
 from ehrql import get_parameter
-age_input = get_parameter("age_band", default="<16")
+age_input = get_parameter("age_band", default=">=11")
 # convert parameter to text string for measure names (filenames)
-age_str = age_input.replace("<", "u").replace("-", "_").replace("65+", "o65")
+age_str = age_input.replace("<", "u").replace("-", "_").replace("65+", "o65").replace(">=11", "all_ages")
 print(age_str)
 # Here we want to create a flag for each female patient of childbearing age, to indicate if
 # they were pregnant on the index/start date, for each month the dataset definition is run.
@@ -35,24 +35,26 @@ dataset.pregnancy_end_code = clinical_events.where(
 
 
 # look ahead for early end-of-pregnancy codes
-# look ahead 16 weeks - early loss could be up to 24 weeks gestation but patient may not know about pregnancy until a few weeks in, 
+# look ahead 12 weeks - early loss could be up to 24 weeks gestation but patient may not know about pregnancy until a few weeks in, 
 # and want to avoid capturing pregnancies that started after the current month
+# miscarriages are most common in the first 12 weeks https://www.tommys.org/baby-loss-support/miscarriage-information-and-support/miscarriage-statistics
 dataset.early_pregnancy_end = clinical_events.where(
     clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_early_loss_pregnancy)
     &
-    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(20))
+    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(12))
     ).sort_by(clinical_events.date).first_for_patient().date
 
 dataset.pregnancy_future_early_end_code = clinical_events.where(
     clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_early_loss_pregnancy)
     &
-    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(20))
+    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(12))
     ).sort_by(clinical_events.date).first_for_patient().snomedct_code
 
 
-# look ahead for full term end-of-pregnancy codes ()
-# look ahead 30 weeks - this captures most relevant pregnancies:
-#   gestation may be 24-40 weeks after excluding early losses;
+# look ahead for full term end-of-pregnancy codes (exclude early losses)
+# look ahead 40 weeks - this captures most relevant pregnancies:
+#   gestation may be 24-40+ weeks after excluding early losses;
+#   vast majority of livebirths will be over 32 weeks gestation https://doi.org/10.1111/j.1365-3016.2008.00965.x;
 #   person may not know about pregnancy until at least 5-6w;
 #   we're also looking across a whole month so some pregnancies may have started 4-5w later than others.
 #   and want to avoid capturing pregnancies that started after the current month.
@@ -112,7 +114,7 @@ dataset.pregnant = case(
          & (dataset.pregnancy_end_recent.is_null() # no past delivery captured
             | ~dataset.pregnancy_end_recent.is_on_or_between(dataset.pregnancy_edd-weeks(28),dataset.pregnancy_edd+weeks(3))
             )).then("P-EDD"),
-    # early loss in month or next 16 weeks - currently pregnant:
+    # early loss in month or next 12 weeks - currently pregnant:
     when(dataset.early_pregnancy_end.is_not_null()).then("P-EL"),
     # full term end of pregnancy in month or next 30 weeks - currently pregnant:
     when(dataset.pregnancy_end.is_on_or_before(INTERVAL.start_date + weeks(30))).then("P-E"),
@@ -123,7 +125,7 @@ dataset.pregnant = case(
 
 # binary flag:
 dataset.pregnant_flag = case(
-    when(dataset.pregnant.is_in(("P-EDD", "P-E", "P"))).then(1),
+    when(dataset.pregnant.is_in(("P-EDD", "P-E", "P-EL", "P"))).then(1),
     otherwise=0,
 )
 
@@ -186,10 +188,16 @@ measures.configure_disclosure_control(enabled=False)
 # we are identifying nearly as many pregnancies in males as females under 16
 # need to check why this is
 
+# select age field on which to filter 
+if age_input == ">=11":
+    age_filter = ">=11"
+else:
+    age_filter = dataset.age_band
+
 measures.define_measure(
     name=f"pregnant_source_{age_str}",
     numerator=dataset.pregnant!= "0",
-    denominator=(dataset.age_band == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex),
+    denominator=(age_filter == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex),
     group_by={
         "source": dataset.pregnant,
         "sex": dataset.sex,
@@ -200,7 +208,7 @@ measures.define_measure(
 measures.define_measure(
     name=f"pregnant_recent_end_code_{age_str}",
     numerator=(dataset.pregnant!= "0"),
-    denominator= (dataset.age_band == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex) & (dataset.pregnancy_end_code.is_not_null()),
+    denominator= (age_filter == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex) & (dataset.pregnancy_end_code.is_not_null()),
     group_by={
         #"source": dataset.pregnant
         "recent_end_code": dataset.pregnancy_end_code,
@@ -212,7 +220,7 @@ measures.define_measure(
 measures.define_measure(
     name=f"pregnant_future_end_code_{age_str}",
     numerator=(dataset.pregnant!= "0"),
-    denominator=(dataset.age_band == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex) & (dataset.pregnancy_future_end_code.is_not_null()),
+    denominator=(age_filter == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex) & (dataset.pregnancy_future_end_code.is_not_null()),
     group_by={
         #"source": dataset.pregnant
         "future_end_code": dataset.pregnancy_future_end_code,
@@ -224,7 +232,7 @@ measures.define_measure(
 measures.define_measure(
     name=f"pregnant_pregnancy_code_{age_str}",
     numerator=(dataset.pregnant!= "0"),
-    denominator=(dataset.age_band == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex) & (dataset.pregnancy_code_snomed.is_not_null()),
+    denominator=(age_filter == age_input) & (dataset.age >=11) & (dataset.has_recorded_sex) & (dataset.pregnancy_code_snomed.is_not_null()),
     group_by={
         #"source": dataset.pregnant
         "pregnancy_code": dataset.pregnancy_code_snomed,
@@ -233,7 +241,9 @@ measures.define_measure(
     },
 )
 
-'''
+
+# general sense checks
+
 measures.define_measure(
     name="ck_pregnancy_future",
     numerator=dataset.ck_pregnancy_future.is_not_null(),
@@ -269,4 +279,3 @@ measures.define_measure(
         "weeks_3": dataset.ck_diff_edd_end_current
     },
 )
-'''

--- a/analysis/check_pregnancy_variables/dataset_definition_pregnancy_measures.py
+++ b/analysis/check_pregnancy_variables/dataset_definition_pregnancy_measures.py
@@ -26,22 +26,40 @@ dataset.pregnancy_end_recent = clinical_events.where(
     clinical_events.date.is_on_or_between(INTERVAL.start_date - weeks(32), INTERVAL.start_date - days(1))
     ).sort_by(clinical_events.date).last_for_patient().date
 
-# get recent end-of-pregnancy codes
+# get recent end-of-pregnancy SNOMED codes
 dataset.pregnancy_end_code = clinical_events.where(
     clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_end_pregnancy)
     &
     clinical_events.date.is_on_or_between(INTERVAL.start_date - weeks(32), INTERVAL.start_date - days(1))
     ).sort_by(clinical_events.date).last_for_patient().snomedct_code
 
-# look ahead for end-of-pregnancy codes
-# look ahead 40 weeks - this captures most relevant pregnancies:
+
+# look ahead for early end-of-pregnancy codes
+# look ahead 16 weeks - early loss could be up to 24 weeks gestation but patient may not know about pregnancy until a few weeks in, 
+# and want to avoid capturing pregnancies that started after the current month
+dataset.early_pregnancy_end = clinical_events.where(
+    clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_early_loss_pregnancy)
+    &
+    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(20))
+    ).sort_by(clinical_events.date).first_for_patient().date
+
+dataset.pregnancy_future_early_end_code = clinical_events.where(
+    clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_early_loss_pregnancy)
+    &
+    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(20))
+    ).sort_by(clinical_events.date).first_for_patient().snomedct_code
+
+
+# look ahead for full term end-of-pregnancy codes ()
+# look ahead 30 weeks - this captures most relevant pregnancies:
+#   gestation may be 24-40 weeks after excluding early losses;
 #   person may not know about pregnancy until at least 5-6w;
-#   but gestation may be longer than 40 weeks;
 #   we're also looking across a whole month so some pregnancies may have started 4-5w later than others.
-# NB We're not splitting between short vs full term pregnancies so we can't be sure when each one started 
-# using this information alone. EDD should capture most though (next variable).
+#   and want to avoid capturing pregnancies that started after the current month.
 dataset.pregnancy_end = clinical_events.where(
     clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_end_pregnancy)
+    &
+    ~clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_early_loss_pregnancy)
     &
     clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(40))
     ).sort_by(clinical_events.date).first_for_patient().date
@@ -49,9 +67,10 @@ dataset.pregnancy_end = clinical_events.where(
 dataset.pregnancy_future_end_code = clinical_events.where(
     clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_end_pregnancy)
     &
+    ~clinical_events.snomedct_code.is_in(codelists.gp_snomed_codelist_early_loss_pregnancy)
+    &
     clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.start_date + weeks(40))
     ).sort_by(clinical_events.date).first_for_patient().snomedct_code
-
 
 # estimated date of delivery (EDD) - very recent or in future
 # to estimate the known start of pregnancy
@@ -79,6 +98,9 @@ dataset.pregnancy_code_snomed = clinical_events.where(
     clinical_events.date.is_on_or_between(INTERVAL.start_date - weeks(12), INTERVAL.start_date + weeks(4))
     ).sort_by(clinical_events.date).first_for_patient().snomedct_code
 
+
+
+
 # combine criteria to create a pregnancy status for the current month:
 dataset.pregnant = case(
     # recent delivery -> not pregnant now:
@@ -90,8 +112,10 @@ dataset.pregnant = case(
          & (dataset.pregnancy_end_recent.is_null() # no past delivery captured
             | ~dataset.pregnancy_end_recent.is_on_or_between(dataset.pregnancy_edd-weeks(28),dataset.pregnancy_edd+weeks(3))
             )).then("P-EDD"),
-    # end of pregnancy in month or next 2 months - currently pregnant:
-    when(dataset.pregnancy_end.is_on_or_before(INTERVAL.start_date + weeks(12))).then("P-E"),
+    # early loss in month or next 16 weeks - currently pregnant:
+    when(dataset.early_pregnancy_end.is_not_null()).then("P-EL"),
+    # full term end of pregnancy in month or next 30 weeks - currently pregnant:
+    when(dataset.pregnancy_end.is_on_or_before(INTERVAL.start_date + weeks(30))).then("P-E"),
     # recent pregnancy code
     when(dataset.pregnancy_code.is_not_null()).then("P"),
     otherwise="0",

--- a/analysis/check_pregnancy_variables/pregnancy_checks.py
+++ b/analysis/check_pregnancy_variables/pregnancy_checks.py
@@ -11,8 +11,7 @@ df = df.loc[df["sex"]=="female"] # drop males here, we asses rates in males and 
 df['year'] = pd.to_datetime(df['interval_start']).dt.year
 
 # Pivot the data to have sources as columns and years as index
-pivot_df = df.pivot(index='year',columns='source', values='denominator')
-print(pivot_df.head())
+pivot_df = df.pivot(index='year',columns='source', values='ratio')
 pivot_df.to_csv(f"{measures_dir}/flag_source_summary_by_year.csv")
 
 # Plot a single bar chart showing the percentage for each source per year

--- a/analysis/check_pregnancy_variables/pregnancy_checks.py
+++ b/analysis/check_pregnancy_variables/pregnancy_checks.py
@@ -5,13 +5,14 @@ import matplotlib.pyplot as plt
 measures_dir = "output/measures"
 
 # Source of pregnant/not pregnant status:
-df = pd.read_csv(f"{measures_dir}/pregnant_source.csv")
-
+df = pd.read_csv(f"{measures_dir}/pregnant_source_all_ages.csv")
+df = df.loc[df["sex"]=="female"] # drop males here, we asses rates in males and by age separately
 # Extract year from interval_start
 df['year'] = pd.to_datetime(df['interval_start']).dt.year
 
 # Pivot the data to have sources as columns and years as index
-pivot_df = df.pivot(index='year', columns='source', values='ratio')
+pivot_df = df.pivot(index='year',columns='source', values='denominator')
+print(pivot_df.head())
 pivot_df.to_csv(f"{measures_dir}/flag_source_summary_by_year.csv")
 
 # Plot a single bar chart showing the percentage for each source per year

--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -150,6 +150,33 @@ gp_snomed_codelist_end_pregnancy = codelist_from_csv(
     category_column="term",
 )
 
+gp_snomed_codelist_miscarriage = codelist_from_csv(
+    "codelists/user-paolomazzone-openpregnosis-miscarriage-codes_v1.csv",
+    column="code",
+)
+
+gp_snomed_codelist_molar_pregnancy = codelist_from_csv(
+    "codelists/user-paolomazzone-openpregnosis-molar-codes_v1.csv",
+    column="code",
+)
+
+gp_snomed_codelist_blighted_ovum_pregnancy = codelist_from_csv(
+    "codelists/user-paolomazzone-openpregnosis-blighted-ovum-codes_v1.csv",
+    column="code",
+)
+
+gp_snomed_codelist_ectopic_pregnancy = codelist_from_csv(
+    "codelists/user-paolomazzone-openpregnosis-ectopic-codes_v1.csv",
+    column="code",
+)
+
+gp_snomed_codelist_early_loss_pregnancy = (
+    gp_snomed_codelist_miscarriage
+    + gp_snomed_codelist_molar_pregnancy
+    + gp_snomed_codelist_blighted_ovum_pregnancy
+    + gp_snomed_codelist_ectopic_pregnancy
+)
+
 # estimated date of delivery
 gp_snomed_codelist_pregnancy_edd = codelist_from_csv (
     "codelists/user-VickiPalin-pregnancy_edd_snomed.csv"

--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -177,6 +177,7 @@ gp_snomed_codelist_early_loss_pregnancy = (
     + gp_snomed_codelist_ectopic_pregnancy
 )
 
+
 # estimated date of delivery
 gp_snomed_codelist_pregnancy_edd = codelist_from_csv (
     "codelists/user-VickiPalin-pregnancy_edd_snomed.csv"

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -167,6 +167,30 @@
       "url": "https://www.opencodelists.org/codelist/pharmacy-first-project/cellulitis-using-snomed-ct-codes/521b1c16/",
       "downloaded_at": "2026-07-06 12:49:12.659426Z",
       "sha": "70f9abf5bb25dca13dcbd0ba30416713fbac3f67"
+    },
+    "user-paolomazzone-openpregnosis-miscarriage-codes_v1.csv": {
+      "id": "user/paolomazzone/openpregnosis-miscarriage-codes_v1/383197f1",
+      "url": "https://www.opencodelists.org/codelist/user/paolomazzone/openpregnosis-miscarriage-codes_v1/383197f1/",
+      "downloaded_at": "2026-08-05 16:07:12.057051Z",
+      "sha": "4607551e164997c05d48f4e49aa13111d0460879"
+    },
+    "user-paolomazzone-openpregnosis-molar-codes_v1.csv": {
+      "id": "user/paolomazzone/openpregnosis-molar-codes_v1/035ff191",
+      "url": "https://www.opencodelists.org/codelist/user/paolomazzone/openpregnosis-molar-codes_v1/035ff191/",
+      "downloaded_at": "2026-08-05 16:07:12.125543Z",
+      "sha": "837bd375f2ffa1ffa7fa7547410576fe207aeb61"
+    },
+    "user-paolomazzone-openpregnosis-blighted-ovum-codes_v1.csv": {
+      "id": "user/paolomazzone/openpregnosis-blighted-ovum-codes_v1/1c6f64c6",
+      "url": "https://www.opencodelists.org/codelist/user/paolomazzone/openpregnosis-blighted-ovum-codes_v1/1c6f64c6/",
+      "downloaded_at": "2026-08-05 16:07:12.189894Z",
+      "sha": "d4b13e79186ef3cf959bb0b99384ada016199875"
+    },
+    "user-paolomazzone-openpregnosis-ectopic-codes_v1.csv": {
+      "id": "user/paolomazzone/openpregnosis-ectopic-codes_v1/6a507e5b",
+      "url": "https://www.opencodelists.org/codelist/user/paolomazzone/openpregnosis-ectopic-codes_v1/6a507e5b/",
+      "downloaded_at": "2026-08-05 16:07:12.284658Z",
+      "sha": "461cf2527664cac3195540c35729ae6bf77f61e5"
     }
   }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -26,3 +26,7 @@ pharmacy-first-project/lower-back-pain-for-pf-control/47b82a84
 pharmacy-first-project/infected-insect-bites-codes-for-pharmacy-first-strict-definition/6b893494
 pharmacy-first-project/all-insect-bites-codes-for-pharmacy-first/12166798
 pharmacy-first-project/cellulitis-using-snomed-ct-codes/521b1c16
+user/paolomazzone/openpregnosis-miscarriage-codes_v1/383197f1 
+user/paolomazzone/openpregnosis-molar-codes_v1/035ff191 
+user/paolomazzone/openpregnosis-blighted-ovum-codes_v1/1c6f64c6 
+user/paolomazzone/openpregnosis-ectopic-codes_v1/6a507e5b 

--- a/codelists/user-paolomazzone-openpregnosis-blighted-ovum-codes_v1.csv
+++ b/codelists/user-paolomazzone-openpregnosis-blighted-ovum-codes_v1.csv
@@ -1,0 +1,3 @@
+code,term
+286996009,Blighted ovum and/or carneous mole
+35999006,Blighted ovum

--- a/codelists/user-paolomazzone-openpregnosis-ectopic-codes_v1.csv
+++ b/codelists/user-paolomazzone-openpregnosis-ectopic-codes_v1.csv
@@ -1,0 +1,50 @@
+code,term
+10455003,Removal of ectopic cervical pregnancy by evacuation
+16836261000119107,Ectopic pregnancy of left ovary
+16836351000119100,Ectopic pregnancy of right ovary
+16836391000119105,Pregnancy of left fallopian tube
+16836431000119100,Ruptured tubal pregnancy of right fallopian tube
+16836571000119103,Ruptured tubal pregnancy of left fallopian tube
+16836891000119104,Pregnancy of right fallopian tube
+17285009,Intraperitoneal pregnancy
+17433009,Ruptured ectopic pregnancy
+176928008,Excision of ectopic ovarian pregnancy
+176929000,Excision of ruptured ectopic tubal pregnancy
+198617006,Delivery of viable fetus in abdominal pregnancy
+198620003,Ruptured tubal pregnancy
+198626009,Mesenteric pregnancy
+198627000,Angular pregnancy
+237253003,Viable fetus in abdominal pregnancy
+237254009,Unruptured tubal pregnancy
+271415006,Removal of products of conception from fallopian tube
+276881003,Secondary abdominal pregnancy
+34801009,Ectopic pregnancy
+35656003,Intraligamentous pregnancy
+387615001,Removal of ectopic pregnancy from fallopian tube
+387616000,Fimbrial extraction of tubal pregnancy
+387617009,Aspiration of ectopic pregnancy from fallopian tube
+387708002,Excision of ectopic abdominal fetus
+387709005,Removal of ectopic fetus from abdominal cavity
+387710000,Removal of extrauterine ectopic fetus
+442478007,Multiple pregnancy involving intrauterine pregnancy and tubal pregnancy
+445912000,Excision of fallopian tube and surgical removal of ectopic pregnancy
+450562009,Laparoscopic excision of ruptured ectopic tubal pregnancy
+450563004,Laparoscopic excision of ectopic ovarian pregnancy
+49964003,Ectopic fetus
+60000008,Mesometric pregnancy
+61893009,Laparoscopic treatment of ectopic pregnancy with oophorectomy
+63596003,Laparoscopic treatment of ectopic pregnancy with salpingectomy
+69532007,Mural pregnancy
+699240001,Combined intrauterine and ovarian pregnancy
+700073007,Aspiration of ectopic pregnancy from cornu of fallopian tube
+73341009,Removal of ectopic fetus from ovary without oophorectomy
+786067000,Intramural ectopic pregnancy of myometrium
+79290002,Cervical pregnancy
+79586000,Tubal pregnancy
+81130000,Removal of intraligamentous ectopic pregnancy
+82661006,Abdominal pregnancy
+82688001,Removal of product of conception of ectopic pregnancy
+87605005,Cornual pregnancy
+88144003,Removal of ectopic interstitial uterine pregnancy requiring total hysterectomy
+88362001,Removal of ectopic fetus from fallopian tube without salpingectomy
+9899009,Ovarian pregnancy

--- a/codelists/user-paolomazzone-openpregnosis-miscarriage-codes_v1.csv
+++ b/codelists/user-paolomazzone-openpregnosis-miscarriage-codes_v1.csv
@@ -1,0 +1,121 @@
+code,term
+10058006,Miscarriage with amniotic fluid embolism
+10697004,Miscarriage complicated by renal failure
+10812041000119103,Urinary tract infection due to incomplete miscarriage
+11026009,Miscarriage with renal tubular necrosis
+11109001,Miscarriage with uremia
+12394009,Miscarriage with cerebral anoxia
+1269247005,Infection of female genital tract due to incomplete miscarriage
+1269249008,Infection of pelvis due to incomplete miscarriage
+1269255003,Damage to organ of pelvis due to incomplete miscarriage
+1269256002,Damage to tissue of pelvis due to incomplete miscarriage
+127009,Miscarriage with laceration of cervix
+13384007,Miscarriage complicated by metabolic disorder
+14136000,Miscarriage with perforation of broad ligament
+1469007,Miscarriage with urinary tract infection
+156072005,Incomplete miscarriage
+156073000,Complete miscarriage
+15809008,Miscarriage with perforation of uterus
+16038004,Abortion due to Leptospira
+16111000119105,Incomplete spontaneous abortion due to hemorrhage
+16607004,Missed abortion
+16714009,Miscarriage with laceration of bowel
+16836811000119108,Miscarriage of left tubal ectopic pregnancy
+16836851000119109,Miscarriage of right tubal ectopic pregnancy
+17369002,Miscarriage
+184339009,Miscarriage at 8 to 28 weeks
+18489003,Surgical treatment of missed abortion of first trimester
+18613002,Miscarriage with septic shock
+19169002,Miscarriage in first trimester
+198644001,Incomplete miscarriage with genital tract or pelvic infection
+198645000,Incomplete miscarriage with delayed or excessive hemorrhage
+198646004,Incomplete miscarriage with damage to pelvic organs or tissues
+198647008,Renal failure due to and following incomplete miscarriage
+198648003,Metabolic disorder due to incomplete miscarriage
+198649006,Shock due to incomplete miscarriage
+198650006,Embolism due to incomplete miscarriage
+198655001,Complete miscarriage with genital tract or pelvic infection
+198656000,Complete miscarriage with delayed or excessive hemorrhage
+198657009,Complete miscarriage with damage to pelvic organs or tissues
+198659007,Complete miscarriage with renal failure
+198660002,Complete miscarriage with metabolic disorder
+198661003,Complete miscarriage with shock
+198663000,Complete miscarriage with embolism
+198861000,"Readmission for retained products of conception, spontaneous abortion"
+198901003,Macerated fetus
+199070009,Papyraceous fetus - not delivered
+199306007,Continuing pregnancy after abortion of one fetus or more
+199307003,Continuing pregnancy after intrauterine death of one or more fetuses
+21360006,Miscarriage with afibrinogenemia
+237245006,Vanishing twin syndrome
+237247003,Continuing pregnancy after abortion of sibling fetus
+23793007,Miscarriage without complication
+275421004,Miscarriage with heavy bleeding
+275425008,Retained products after miscarriage
+2781009,Miscarriage complicated by delayed and/or excessive hemorrhage
+307733001,Inevitable abortion complete
+307734007,Complete inevitable abortion complicated by genital tract and pelvic infection
+307735008,Complete inevitable abortion complicated by delayed or excessive hemorrhage
+307737000,Inevitable abortion incomplete
+307746006,Incomplete inevitable abortion complicated by embolism
+307749004,Incomplete inevitable abortion complicated by genital tract and pelvic infection
+307750004,Complete inevitable abortion complicated by embolism
+307752007,Incomplete inevitable abortion complicated by delayed or excessive hemorrhage
+30806007,Miscarriage with endometritis
+34270000,Miscarriage complicated by shock
+34614007,Miscarriage with complication
+35381000119101,Quadruplet pregnancy with loss of one or more fetuses
+363681007,Pregnancy with abortive outcome
+36801000119105,Continuing triplet pregnancy after spontaneous abortion of one or more fetuses
+373896005,Miscarriage complicated by genital-pelvic infection
+38651009,Fetal mummification
+39199000,Miscarriage with laceration of urinary bladder
+40444006,Miscarriage with acute necrosis of liver
+413338003,Incomplete miscarriage with complication
+428508008,Abortion due to Brucella abortus
+428511009,Multiple pregnancy with one fetal loss
+429187001,Continuing pregnancy after intrauterine death of twin fetus
+43306002,Miscarriage complicated by embolism
+445548006,Dead fetus in utero
+44814008,Miscarriage with laceration of periurethral tissue
+472321009,Continuing pregnancy after intrauterine death of one twin with intrauterine retention of dead twin
+47537002,Miscarriage with postoperative shock
+48485000,Miscarriage in third trimester
+48739004,Miscarriage with cardiac arrest and/or cardiac failure
+50770000,Miscarriage with defibrination syndrome
+5191001,Surgical treatment of missed abortion of second trimester
+51954003,Miscarriage with perforation of periurethral tissue
+53183006,Miscarriage with intravascular hemolysis
+53898005,Lithopedion
+55976003,Miscarriage with blood-clot embolism
+57420002,Listeria abortion
+57469000,Miscarriage with acute renal failure
+58990004,Miscarriage complicated by damage to pelvic organs and/or tissues
+59204004,Miscarriage with septic embolism
+59291004,Undelivered in utero fetal death
+59363009,Inevitable abortion
+60265009,Miscarriage with air embolism
+609525000,Miscarriage of tubal ectopic pregnancy
+61568004,Miscarriage with salpingo-oophoritis
+64814003,Miscarriage with electrolyte imbalance
+66131005,Miscarriage with fat embolism
+67465009,Miscarriage with sepsis
+697954007,Miscarriage care
+7000009,Fetal demise from miscarriage
+72613009,Miscarriage with oliguria
+737318003,Delayed hemorrhage due to and following miscarriage
+737331008,Disorder of vein following miscarriage
+74369005,Miscarriage with perforation of cervix
+749781000000109,Incomplete termination of pregnancy
+7809009,Miscarriage with laceration of uterus
+7910003,Miscarriage with salpingitis
+8071005,Miscarriage with perforation of bowel
+82153002,Miscarriage with pulmonary embolism
+83922009,Miscarriage with parametritis
+85116003,Miscarriage in second trimester
+85331004,Miscarriage with laceration of broad ligament
+85467007,Miscarriage with perforation of urinary bladder
+85632001,Miscarriage with laceration of vagina
+85991008,Miscarriage with pelvic peritonitis
+87967003,Miscarriage with perforation of vagina
+90127001,Fetus papyraceous

--- a/codelists/user-paolomazzone-openpregnosis-molar-codes_v1.csv
+++ b/codelists/user-paolomazzone-openpregnosis-molar-codes_v1.csv
@@ -1,0 +1,8 @@
+code,term
+237249000,Complete hydatidiform mole
+237250000,Incomplete hydatidiform mole
+416669000,Invasive hydatidiform mole
+417044008,"Hydatidiform mole, benign"
+445149007,Residual trophoblastic disease
+44782008,Molar pregnancy
+44979007,Carneous mole

--- a/project.yaml
+++ b/project.yaml
@@ -22,6 +22,13 @@ actions:
       highly_sensitive:
         dataset: output/dataset_preg_2025_11_01.csv.gz
 
+  generate_dataset_preg_measures: 
+    run: ehrql:v1 generate-measures analysis/check_pregnancy_variables/dataset_definition_pregnancy_measures.py --output output/measures/:csv
+    outputs:
+      moderately_sensitive:
+        dataset: output/measures/ck_*.csv
+        dataset2: output/measures/pregnant_source_all_ages.csv
+
   generate_dataset_preg_measures_u16: 
     run: ehrql:v1 generate-measures analysis/check_pregnancy_variables/dataset_definition_pregnancy_measures.py --output output/measures/:csv -- --age_band "<16"
     outputs:
@@ -40,14 +47,14 @@ actions:
       moderately_sensitive:
         dataset: output/measures/*_o65.csv
 
-#analyse_preg_measures:
-#   run: python:v2 analysis/check_pregnancy_variables/pregnancy_checks.py --output output/measures/pregnancy_checks.csv --input output/measures/*.csv
-#   needs: 
-#     [generate_dataset_preg_measures]
-#   outputs:
-#     moderately_sensitive:
-#       dataset: output/measures/*by_year.csv
-#       charts: output/measures/*by_year.png
+  analyse_preg_measures:
+    run: python:v2 analysis/check_pregnancy_variables/pregnancy_checks.py --output output/measures/pregnancy_checks.csv --input output/measures/*.csv
+    needs: 
+      [generate_dataset_preg_measures]
+    outputs:
+      moderately_sensitive:
+        dataset: output/measures/*by_year.csv
+        charts: output/measures/*by_year.png
 
   analyse_preg_measures_agesex:
     run: python:v2 analysis/check_pregnancy_variables/pregnancy_checks_age_sex.py --output output/measures/:csv --input output/measures/*.csv


### PR DESCRIPTION
Add early loss codelists so that gestation length can be refined in the algorithm
I.e. pregnancy status based on future end-of-pregnancy is now split as follows:
- early loss in next 12 weeks -> pregnant in current month
- other end of pregnancy (excluding early loss codes) in next 30 weeks -> pregnant in current month